### PR TITLE
Check for duplicate record type field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ We support [Dhall 15.0.0][dhall-15], including the `with` keyword and record pun
 
 We're running the [Dhall acceptance test suites][dhall-tests] for parsing, normalization,
 [CBOR][cbor] encoding and decoding, hashing, and type inference (everything except imports), and
-currently 1,139 of 1,143 tests are passing. There are three open issues that track the acceptance
+currently 1,140 of 1,143 tests are passing. There are two open issues that track the acceptance
 tests that are not passing or that we're not running yet:
-[#5](https://github.com/travisbrown/dhallj/issues/5),
-[#6](https://github.com/travisbrown/dhallj/issues/6), and
+[#5](https://github.com/travisbrown/dhallj/issues/5) and
 [#8](https://github.com/travisbrown/dhallj/issues/8).
 
 There are several known issues:

--- a/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheckFailure.java
+++ b/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheckFailure.java
@@ -122,6 +122,10 @@ public final class TypeCheckFailure extends DhallException {
     return new TypeCheckFailure("Invalid field type");
   }
 
+  static TypeCheckFailure makeFieldDuplicateError(String fieldName) {
+    return new TypeCheckFailure(String.format("duplicate field: %s", fieldName));
+  }
+
   static TypeCheckFailure makeListTypeMismatchError(Expr type1, Expr type2) {
     return new TypeCheckFailure("List elements should all have the same type");
   }

--- a/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
+++ b/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
@@ -28,10 +28,7 @@ class TypeCheckingOtherSuite extends TypeCheckingSuite("type-inference/success")
   override def ignored = Set("CacheImports", "CacheImportsCanonicalize")
   override def slow = Set("prelude")
 }
-class TypeCheckingFailureUnitSuite extends TypeCheckingFailureSuite("type-inference/failure/unit") {
-  // The spec says we shouldn't have to worry about duplicate fields during type checking.
-  override def ignored = Set("RecordTypeDuplicateField")
-}
+class TypeCheckingFailureUnitSuite extends TypeCheckingFailureSuite("type-inference/failure/unit")
 
 class ParsingUnitSuite extends ParsingSuite("parser/success/unit") {
   override def ignored = Set("SomeXYZ")


### PR DESCRIPTION
Fixes #6:

```scala
scala> import org.dhallj.syntax._
import org.dhallj.syntax._

scala> val Left(failure) = "{x: Natural, x: Natural}".parseExpr.flatMap(_.typeCheck)
failure: org.dhallj.core.DhallException = org.dhallj.core.typechecking.TypeCheckFailure: duplicate field: x
```

We follow the Haskell implementation in failing fast on duplicate field names even if there are invalid type errors:

```scala
scala> val Left(failure) = "{x: Natural, x: 0}".parseExpr.flatMap(_.typeCheck)
failure: org.dhallj.core.DhallException = org.dhallj.core.typechecking.TypeCheckFailure: duplicate field: x
```
Compare:
```bash
$ dhall --explain <<< "{x: Natural, x: 0}"
dhall: 
Error: Invalid input

(stdin):1:18:
  |
1 | {x: Natural, x: 0}
  |                  ^
duplicate field: x
```