### PR TITLE
Add toString round-trip test for unnormalized Prelude

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - $HOME/.sbt/boot
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean javacc scalafmtCheckAll scalafmtSbtCheck test
+  - sbt ++$TRAVIS_SCALA_VERSION clean javacc scalafmtCheckAll scalafmtSbtCheck test slow:test
   # See http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/tests/src/test/scala/org/dhallj/tests/ToStringSuite.scala
+++ b/tests/src/test/scala/org/dhallj/tests/ToStringSuite.scala
@@ -1,6 +1,6 @@
 package org.dhallj.tests
 
-import munit.{Ignore, ScalaCheckSuite}
+import munit.{Ignore, ScalaCheckSuite, Slow}
 import org.dhallj.core.Expr
 import org.dhallj.parser.DhallParser
 import org.dhallj.testing.WellTypedExpr
@@ -14,5 +14,15 @@ class ToStringSuite extends ScalaCheckSuite() {
 
   property("toString produces parseable code".tag(Ignore)) {
     Prop.forAll((expr: Expr) => DhallParser.parse(clue(expr.toString)) == expr)
+  }
+
+  test("Unnormalized Prelude should round-trip through toString".tag(Slow)) {
+    import org.dhallj.syntax._
+
+    val Right(prelude) = "./dhall-lang/Prelude/package.dhall".parseExpr.flatMap(_.resolve)
+    val Right(fromToString) = prelude.toString.parseExpr
+
+    assert(prelude.hash.sameElements(fromToString.hash))
+    assert(prelude.diff(fromToString).isEmpty)
   }
 }


### PR DESCRIPTION
This test validates the fix for #7. I've tagged it as slow because it takes around 12 seconds to run.

I've also turned on the slow tests in CI (right now they only take about an extra minute and a half).