### PR TITLE
Fix caching behaviour of type inference acceptance tests

### DIFF
--- a/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
@@ -82,7 +82,8 @@ abstract class ExprOperationAcceptanceSuite(transformation: Expr => Expr) extend
   def compare(result: Expr, expected: Expr): Boolean = result.sameStructure(expected) && result.equivalent(expected)
 }
 
-abstract class CachingExprOperationAcceptanceSuite(transformation: Expr => Expr) extends CachingResolvingExprAcceptanceSuite[Expr] {
+abstract class CachingExprOperationAcceptanceSuite(transformation: Expr => Expr)
+    extends CachingResolvingExprAcceptanceSuite[Expr] {
   def makeExpectedPath(inputPath: String): String = inputPath.dropRight(7) + "B.dhall"
 
   def transform(input: Expr): Expr = transformation(input)

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/ImportResolutionSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/ImportResolutionSuite.scala
@@ -17,7 +17,7 @@ import org.http4s.client.blaze._
 import scala.concurrent.ExecutionContext.global
 import scala.io.Source
 
-class ImportResolutionSuite(val base: String) extends ExprOperationAcceptanceSuite(_.normalize) {
+class ImportResolutionSuite(val base: String) extends CachingExprOperationAcceptanceSuite(_.normalize) {
 
   setEnv("DHALL_TEST_VAR", "6 * 7") //Yes, this is SUPER hacky but the JVM doesn't really support setting env vars
 

--- a/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
+++ b/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
@@ -21,8 +21,8 @@ class HashingHTProjectionSuite extends HashingSuite("semantic-hash/success/haske
 class AlphaNormalizationUnitSuite extends AlphaNormalizationSuite("alpha-normalization/success/unit")
 class AlphaNormalizationRegressionSuite extends AlphaNormalizationSuite("alpha-normalization/success/regression")
 
-class TypeCheckingSimpleSuite extends TypeCheckingSuite("type-inference/success/simple")
-class TypeCheckingUnitSuite extends TypeCheckingSuite("type-inference/success/unit")
+class TypeCheckingSimpleSuite extends CachingTypeCheckingSuite("type-inference/success/simple")
+class TypeCheckingUnitSuite extends CachingTypeCheckingSuite("type-inference/success/unit")
 class TypeCheckingRegressionSuite extends TypeCheckingSuite("type-inference/success/regression")
 class TypeCheckingOtherSuite extends TypeCheckingSuite("type-inference/success") {
   override def slow = Set("prelude")


### PR DESCRIPTION
As per https://github.com/dhall-lang/dhall-lang/tree/master/tests
only the simple and unit tests should be run with a cache