### PR TITLE
Fix parsing bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import ReleaseTransformations._
 
 organization in ThisBuild := "org.dhallj"
 
+val previousVersion = "0.1.0"
 val circeVersion = "0.13.0"
 
 val testDependencies = Seq(
@@ -17,10 +18,13 @@ val baseSettings = Seq(
 
 val javaSettings = Seq(
   autoScalaLibrary := false,
-  crossPaths := false
+  crossPaths := false,
+  mimaPreviousArtifacts := Set("org.dhallj" % moduleName.value % previousVersion)
 )
 
-val scalaSettings = Seq()
+val scalaSettings = Seq(
+  mimaPreviousArtifacts := Set("org.dhallj" %% moduleName.value % previousVersion)
+)
 
 val root = project
   .in(file("."))
@@ -28,6 +32,7 @@ val root = project
   .settings(baseSettings ++ publishSettings)
   .settings(
     skip in publish := true,
+    mimaPreviousArtifacts := Set.empty,
     initialCommands in console := "import org.dhallj.parser.DhallParser.parse",
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
@@ -101,6 +106,7 @@ lazy val cli = project
   .settings(baseSettings ++ javaSettings)
   .settings(
     skip in publish := true,
+    mimaPreviousArtifacts := Set.empty,
     name in GraalVMNativeImage := "dhall-cli"
   )
   .enablePlugins(GraalVMNativeImagePlugin)
@@ -224,6 +230,7 @@ lazy val tests = project
       "org.http4s" %% "http4s-blaze-client" % "0.21.3"
     ),
     skip in publish := true,
+    mimaPreviousArtifacts := Set.empty,
     unmanagedResourceDirectories.in(Test) += (ThisBuild / baseDirectory).value / "dhall-lang",
     testOptions.in(Test) += Tests.Argument("--exclude-tags=Slow"),
     inConfig(Slow)(Defaults.testTasks),
@@ -236,7 +243,8 @@ lazy val benchmarks = project
   .in(file("benchmarks"))
   .settings(baseSettings ++ scalaSettings)
   .settings(
-    skip in publish := true
+    skip in publish := true,
+    mimaPreviousArtifacts := Set.empty
   )
   .enablePlugins(JmhPlugin)
   .dependsOn(core, prelude)

--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -422,7 +422,7 @@ public abstract class Expr {
           if (quoted) {
             builder.append("\\\\u0024");
           } else {
-            builder.append("\\u0024");
+            builder.append("$");
           }
         } else if (c == '\\') {
           if (quoted) {

--- a/modules/core/src/main/java/org/dhallj/core/converters/JsonConverter.java
+++ b/modules/core/src/main/java/org/dhallj/core/converters/JsonConverter.java
@@ -32,7 +32,30 @@ public final class JsonConverter extends Visitor.Constant<Boolean> {
   }
 
   private static final String escape(String input) {
-    return input.replace("\"", "\\\"").replace("\\$", "$");
+    StringBuilder builder = new StringBuilder();
+
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+
+      if (c == '\\') {
+        char next = input.charAt(++i);
+
+        if (next == '"') {
+          builder.append("\\\"");
+        } else if (next == '$') {
+          builder.append("$");
+        } else {
+          builder.append(c);
+          builder.append(next);
+        }
+      } else if (c == '"') {
+        builder.append("\\\"");
+      } else {
+        builder.append(c);
+      }
+    }
+
+    return builder.toString();
   }
 
   @Override

--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -209,8 +209,9 @@ TOKEN: {
     braceDepth.push(0);
     SwitchTo(DEFAULT);
   } |
+  <DOUBLE_QUOTE_DOLLAR_SIGN: "$"> |
   <DOUBLE_QUOTE_CHARS: (
-      "\u0020" | "\u0021" | ["\u0025"-"\u005b"] | ["\u005d"-"\u007f"]
+      "\u0020" | "\u0021" | "#" | ["\u0025"-"\u005b"] | ["\u005d"-"\u007f"]
     | ("\\" (["\"", "$", "\\", "/", "b", "f", "n", "r", "t"]))
     | ("\\u" <UNICODE_ESCAPE>)
     | <VALID_NON_ASCII>
@@ -256,11 +257,30 @@ Wrapped<String> ANY_LABEL_OR_SOME():  {
 }
 
 Map.Entry<String, Expr.Parsed> DOUBLE_QUOTE_CHUNK(): {
-  Token token = null;
+  StringBuilder builder = null;
+  Token token0 = null;
+  Token token1 = null;
   Expr.Parsed expr = null;
 } {
-  ((<DOUBLE_QUOTE_INTERPOLATION> expr=COMPLETE_EXPRESSION() <BRACE_CLOSE>) | token=<DOUBLE_QUOTE_CHARS>) {
-    return new SimpleImmutableEntry(token == null ? null : token.image, expr);
+  (
+      (<DOUBLE_QUOTE_INTERPOLATION> expr=COMPLETE_EXPRESSION() <BRACE_CLOSE>)
+    | (
+      (token0=<DOUBLE_QUOTE_DOLLAR_SIGN> | token0=<DOUBLE_QUOTE_CHARS>)
+      (LOOKAHEAD(2)
+        (token1=<DOUBLE_QUOTE_DOLLAR_SIGN> | token1=<DOUBLE_QUOTE_CHARS>) {
+          if (builder == null) {
+            builder = new StringBuilder(token0.image);
+          }
+          builder.append(token1.image);
+        }
+      )*
+    )
+  ) {
+    if (builder == null) {
+      return new SimpleImmutableEntry(token0 == null ? null : token0.image, expr);
+    } else {
+      return new SimpleImmutableEntry(builder.toString(), expr);
+    }
   }
 }
 

--- a/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
+++ b/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
@@ -18,4 +18,16 @@ class DhallParserSuite extends FunSuite() {
 
     assert(DhallParser.parse("https://[0:0:0:0:0:0:0:1]/") == expected)
   }
+
+  test("parse $ in double-quoted text literals") {
+    val expected = Expr.makeTextLiteral("$ $ $100 $ $")
+
+    assert(DhallParser.parse("""let x = "100" in "$ $ $${x} $ $" """) == expected)
+  }
+
+  test("parse # in double-quoted text literals") {
+    val expected = Expr.makeTextLiteral("# # # $ % ^ #")
+
+    assert(DhallParser.parse(""""# # # $ % ^ #"""") == expected)
+  }
 }

--- a/tests/src/test/scala/org/dhallj/tests/JsonConverterSuite.scala
+++ b/tests/src/test/scala/org/dhallj/tests/JsonConverterSuite.scala
@@ -6,19 +6,19 @@ import org.dhallj.parser.DhallParser
 
 class JsonConverterSuite extends FunSuite() {
   test("toCompactString correctly escapes text") {
-    val expr = DhallParser.parse(
-      """[{mapKey = " \n \$ \" ", mapValue = " \n \$ \" "}]"""
-    )
+    val expr = DhallParser.parse("""[{mapKey = " \n \$ \" ", mapValue = " \n \$ \" "}]""")
 
     assert(clue(JsonConverter.toCompactString(expr)) == clue("""{" \n $ \" ":" \n $ \" "}"""))
   }
 
+  test("toCompactString correctly escapes text from Text/show") {
+    val expr = DhallParser.parse("""Text/show "$100 #"""").normalize
+
+    assert(clue(JsonConverter.toCompactString(expr)) == clue(""""\"\\u0024100 #\"""""))
+  }
+
   test("toCompactString correctly escapes text from toMap") {
-    val expr = DhallParser
-      .parse(
-        """toMap {` \n \$ \" ` = " \n \$ \" "}"""
-      )
-      .normalize
+    val expr = DhallParser.parse("""toMap {` \n \$ \" ` = " \n \$ \" "}""").normalize
 
     assert(clue(JsonConverter.toCompactString(expr)) == clue("""{" \\n \\$ \\\" ":" \n $ \" "}"""))
   }


### PR DESCRIPTION
This PR does three things:

* Fixes #21, a bug in the parser that was reported by @amesgen and was due to me mistranscribing the `double-quote-char` rule from `dhall.abnf`.
* Fixes an issue in JSON export that I noticed while investigating the parser bug.
* Enables [MiMa](https://github.com/lightbend/mima) binary compatibility checking in preparation for a new release today. 