### PR TITLE
Fix acceptance test file selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We support [Dhall 15.0.0][dhall-15], including the `with` keyword and record pun
 
 We're running the [Dhall acceptance test suites][dhall-tests] for parsing, normalization,
 [CBOR][cbor] encoding and decoding, hashing, and type inference (everything except imports), and
-currently 1,140 of 1,143 tests are passing. There are two open issues that track the acceptance
+currently 1,025 of 1,040 tests are passing. There are two open issues that track the acceptance
 tests that are not passing or that we're not running yet:
 [#5](https://github.com/travisbrown/dhallj/issues/5) and
 [#8](https://github.com/travisbrown/dhallj/issues/8).

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
@@ -122,9 +122,7 @@ class ParsingSuite(val base: String) extends SuccessSuite[Expr, Array[Byte]] wit
   def compare(result: Array[Byte], expected: Array[Byte]): Boolean = result.sameElements(expected)
 }
 
-abstract class ExprDecodingAcceptanceSuite(transformation: Expr => Expr)
-    extends SuccessSuite[Expr, Expr]
-    with ParsingInput {
+class BinaryDecodingSuite(val base: String) extends SuccessSuite[Expr, Expr] with ParsingInput {
   def makeExpectedPath(inputPath: String): String = inputPath.dropRight(8) + "B.dhall"
 
   override def isInputFileName(fileName: String): Boolean = fileName.endsWith("A.dhallb")
@@ -132,9 +130,7 @@ abstract class ExprDecodingAcceptanceSuite(transformation: Expr => Expr)
   override def parseInput(path: String, input: String): Expr =
     decode(readBytes(path))
 
-  def transform(input: Expr): Expr = transformation(input)
+  def transform(input: Expr): Expr = input
   def loadExpected(input: Array[Byte]): Expr = DhallParser.parse(new String(input))
   def compare(result: Expr, expected: Expr): Boolean = result.sameStructure(expected) && result.equivalent(expected)
 }
-
-class BinaryDecodingSuite(val base: String) extends ExprDecodingAcceptanceSuite(identity)

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuite.scala
@@ -8,7 +8,7 @@ trait AcceptanceSuite extends FunSuite {
   def prefix: String = "tests"
   def base: String
 
-  def isInputFileName(fileName: String): Boolean = fileName.endsWith(".dhall")
+  def isInputFileName(fileName: String): Boolean = fileName.endsWith("A.dhall")
   def makeName(inputFileName: String): String = inputFileName.dropRight(7)
 
   /**


### PR DESCRIPTION
Redoes @TimWSpence's change that I mistakenly undid. I've also flattened the `ExprDecodingAcceptanceSuite` class since I don't think it's likely we'll ever need more than `BinaryDecodingSuite`.