### PR TITLE
Use -target 1.7 for all Java modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ val baseSettings = Seq(
 val javaSettings = Seq(
   autoScalaLibrary := false,
   crossPaths := false,
+  javacOptions in Compile ++= Seq("-source", "1.7"),
+  javacOptions in (Compile, compile) ++= Seq("-target", "1.7"),
   mimaPreviousArtifacts := Set("org.dhallj" % moduleName.value % previousVersion)
 )
 
@@ -74,9 +76,7 @@ lazy val core = project
   .settings(
     moduleName := "dhall-core",
     name := "dhall-core",
-    description := "DhallJ core",
-    javacOptions in Compile ++= Seq("-source", "1.7"),
-    javacOptions in (Compile, compile) ++= Seq("-target", "1.7")
+    description := "DhallJ core"
   )
 
 lazy val parser = project

--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -505,7 +505,7 @@ Expr.Parsed RECORD_LITERAL_OR_TYPE(): {
     } else if (typeValues != null) {
       return ParsingHelpers.makeRecordType(typeValues, first, last);
     } else {
-      return ParsingHelpers.makeRecordType(new ArrayList<>(), first, last);
+      return ParsingHelpers.makeRecordType(new ArrayList<Map.Entry<String, Expr.Parsed>>(), first, last);
     }
   }
 }


### PR DESCRIPTION
We hadn't been building the non-core Java modules with `-target 1.7`. After this change, you can build with `sbt assembly` as usual on Java 8+, and then:

```bash
$ sudo archlinux-java set java-7-openjdk
$ java -version
OpenJDK Runtime Environment (IcedTea 2.6.19) (Arch Linux build 7.u231_2.6.19-1-x86_64)
OpenJDK 64-Bit Server VM (build 24.231-b01, mixed mode)
$ java -jar cli/target/cli-assembly-0.1.2-SNAPSHOT.jar hash --normalize --alpha <<< "λ(n: Natural) → [n, n + 1]"
sha256:a8d9326812aaabeed29412e7b780dc733b1e633c5556c9ea588e8212d9dc48f3
```
So I'm considering #15 done.