### PR TITLE
Fix parser issue on type annotations in e.g. empty list type annotations

### DIFF
--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -696,7 +696,7 @@ Expr.Parsed APPLICATION_EXPRESSION(): {
         [whsp2=<WHSP>]
         <COLON>
         whsp3=<WHSP>
-        type=APPLICATION_EXPRESSION()
+        type=BASE_EXPRESSION()
       )?) {
         base = ParsingHelpers.makeMerge(expr, other, type, first, whsp0, whsp1, whsp2, whsp3);
       }
@@ -710,7 +710,7 @@ Expr.Parsed APPLICATION_EXPRESSION(): {
         [whsp2=<WHSP>]
         <COLON>
         whsp3=<WHSP>
-        type=APPLICATION_EXPRESSION()
+        type=BASE_EXPRESSION()
       )?) {
           base = ParsingHelpers.makeToMap(expr, type, first, whsp0, whsp2, whsp3);
       }
@@ -828,7 +828,7 @@ Expr.Parsed EMPTY_LIST_LITERAL(): {
       builder.append(':');
       builder.append(t0.image);
     }
-    type=APPLICATION_EXPRESSION()
+    type=BASE_EXPRESSION()
   ) {
     return ParsingHelpers.makeEmptyListLiteral(type, builder.toString(), first);
   }

--- a/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
+++ b/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
@@ -8,12 +8,46 @@ import org.dhallj.core.Expr
 import org.dhallj.core.Expr.ImportMode
 
 class DhallParserSuite extends FunSuite() {
-  test("parse empty list with annotation on element type".tag(Ignore)) {
+  test("parse empty list with annotation on element type") {
     val expected = Expr.makeEmptyListLiteral(
-      Expr.makeApplication(Expr.Constants.LIST, Expr.makeAnnotated(Expr.Constants.NATURAL, Expr.Constants.TYPE))
+      Expr.makeAnnotated(Expr.makeApplication(Expr.Constants.LIST, Expr.Constants.NATURAL), Expr.Constants.TYPE)
     )
+    // Output from dhall-haskell.
+    val expectedBytes: Array[Byte] = Array(-126, 24, 28, -125, 24, 26, -125, 0, 100, 76, 105, 115, 116, 103, 78, 97,
+      116, 117, 114, 97, 108, 100, 84, 121, 112, 101)
+    val parsed = DhallParser.parse("[]: List Natural: Type")
 
-    assert(DhallParser.parse("[]: List Natural: Type") == expected)
+    assert(parsed == expected)
+    assert(parsed.getEncodedBytes.sameElements(expectedBytes))
+  }
+
+  test("parse toMap with empty record with annotation on type") {
+    // Output from dhall-haskell.
+    val expectedBytes: Array[Byte] = Array(-125, 24, 27, -126, 7, -96, -125, 24, 26, -125, 0, 100, 76, 105, 115, 116,
+      -126, 7, -94, 102, 109, 97, 112, 75, 101, 121, 100, 84, 101, 120, 116, 104, 109, 97, 112, 86, 97, 108, 117, 101,
+      100, 66, 111, 111, 108, 100, 84, 121, 112, 101)
+    val parsed = DhallParser.parse("toMap {}: List { mapKey : Text, mapValue: Bool }: Type")
+
+    assert(parsed.getEncodedBytes.sameElements(expectedBytes))
+  }
+
+  test("parse toMap with empty non-record with annotation on type") {
+    // Output from dhall-haskell.
+    val expectedBytes: Array[Byte] = Array(-125, 24, 27, -126, 8, -95, 97, 97, -11, -125, 24, 26, -125, 0, 100, 76, 105,
+      115, 116, -126, 7, -94, 102, 109, 97, 112, 75, 101, 121, 100, 84, 101, 120, 116, 104, 109, 97, 112, 86, 97, 108,
+      117, 101, 100, 66, 111, 111, 108, 100, 84, 121, 112, 101)
+    val parsed = DhallParser.parse("toMap {a=True}: List { mapKey : Text, mapValue: Bool }: Type")
+
+    assert(parsed.getEncodedBytes.sameElements(expectedBytes))
+  }
+
+  test("parse merge with annotation on type") {
+    // Output from dhall-haskell.
+    val expectedBytes: Array[Byte] = Array(-124, 6, -126, 8, -95, 97, 97, -126, 15, 1, -125, 9, -126, 11, -95, 97, 97,
+      -10, 97, 97, -125, 24, 26, 103, 78, 97, 116, 117, 114, 97, 108, 100, 84, 121, 112, 101)
+    val parsed = DhallParser.parse("merge {a=1} <a>.a: Natural: Type")
+
+    assert(clue(parsed.getEncodedBytes).sameElements(clue(expectedBytes)))
   }
 
   test("parse IPv6 address") {


### PR DESCRIPTION
Fixes #1, and I don't think it breaks anything else. That turned out to be extremely easy.

I was following the spec in my initial implementation, and I think there might be a bug there. For example:

```
empty-list-literal =
    "[" whsp [ "," whsp ] "]" whsp ":" whsp1 application-expression
```

And similarly `toMap` and `merge` have `application-expression` for their type annotations, but e.g. dhall-haskell is perfectly happy to parse `[]: List Natural: Type`, where the type annotation doesn't match `application-expression`. If I'm reading the ABNF correctly and what dhall-haskell is doing doesn't match it, it seems to me like dhall-haskell is doing the right thing, and I think we should follow it here (I could just be confusing myself, though).

The change in this PR just replaces my JavaCC equivalents of `application-expression` with `expression` in the grammar, and it makes the parser match dhall-haskell (apparently) without breaking anything else.

