### PR TITLE
Let SnakeYAML do its own escaping for newlines

### DIFF
--- a/modules/yaml/src/main/java/org/dhallj/yaml/YamlConverter.java
+++ b/modules/yaml/src/main/java/org/dhallj/yaml/YamlConverter.java
@@ -16,6 +16,14 @@ public class YamlConverter {
     return toYamlString(expr, defaultOptions, true);
   }
 
+  public static final String toYamlString(Expr expr, DumperOptions options) {
+    return toYamlString(expr, options, true);
+  }
+
+  public static final String toYamlString(Expr expr, boolean skipNulls) {
+    return toYamlString(expr, defaultOptions, skipNulls);
+  }
+
   public static final String toYamlString(Expr expr, DumperOptions options, boolean skipNulls) {
     YamlHandler handler = new YamlHandler(skipNulls);
     boolean wasConverted = expr.accept(new JsonConverter(handler));

--- a/modules/yaml/src/main/java/org/dhallj/yaml/YamlHandler.java
+++ b/modules/yaml/src/main/java/org/dhallj/yaml/YamlHandler.java
@@ -46,7 +46,7 @@ public class YamlHandler implements JsonHandler {
   }
 
   public void onString(String value) {
-    this.addValue(value);
+    this.addValue(value.replaceAll("\\\\n", "\n"));
   }
 
   public void onArrayStart() {


### PR DESCRIPTION
Fixes #27 by giving SnakeYAML strings with unescaped newlines and letting it handle any possible escaping itself.

```scala
scala> import org.dhallj.parser.DhallParser.parse, org.dhallj.yaml.YamlConverter
import org.dhallj.parser.DhallParser.parse
import org.dhallj.yaml.YamlConverter

scala> YamlConverter.toYamlString(parse(""" { a = "\n" } """).normalize())
res0: String =
"a: |2+

"

scala> YamlConverter.toYamlString(parse(""" { a = "foo\nbar" } """).normalize())
res1: String =
"a: |-
  foo
  bar
"
```
This output isn't identical to `dhall-to-yaml` at the string level, but it should be equivalent as YAML, and it's possible to pass in SnakeYAML configuration if you want a different scalar style. For example:

```scala
scala> import org.yaml.snakeyaml.DumperOptions
import org.yaml.snakeyaml.DumperOptions

scala> val options = new DumperOptions()
options: org.yaml.snakeyaml.DumperOptions = org.yaml.snakeyaml.DumperOptions@78a03a2e

scala> options.setDefaultScalarStyle(DumperOptions.ScalarStyle.DOUBLE_QUOTED)

scala> YamlConverter.toYamlString(parse(""" { a = "foo\nbar" } """).normalize(), options)
res3: String =
""a": "foo\nbar"
"
```
At some point we might want the default SnakeYAML configuration to match `dhall-to-yaml` more exactly, but this doesn't seem like a high priority.