### PR TITLE
Fix quoted URL path failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ team.
 
 ## Status
 
-We support [Dhall 15.0.0][dhall-15], including the `with` keyword and record puns.
+We support [Dhall 15.0.0][dhall-15], including the `with` keyword and record puns. We do not support
+[URLs with quoted paths](https://docs.dhall-lang.org/howtos/migrations/Deprecation-of-quoted-paths-in-URLs.html),
+which were deprecated in 15.0.0 and will be removed in 17.0.0. We currently do support
+`Optional/build` and `Optional/fold`, which will also be removed in 17.0.0.
+
 
 We're running the [Dhall acceptance test suites][dhall-tests] for parsing, normalization,
 [CBOR][cbor] encoding and decoding, hashing, and type inference (everything except imports), and

--- a/modules/parser/src/main/java/org/dhallj/parser/support/ParsingHelpers.java
+++ b/modules/parser/src/main/java/org/dhallj/parser/support/ParsingHelpers.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import org.dhallj.core.DhallException.ParsingFailure;
 import org.dhallj.core.Expr;
 import org.dhallj.core.Operator;
 import org.dhallj.core.Source;
@@ -664,7 +665,7 @@ final class ParsingHelpers {
       try {
         value = Expr.makeRemoteImport(new URI(type.image), using, mode, hash);
       } catch (java.net.URISyntaxException e) {
-        System.out.println(e);
+        throw new ParsingFailure("Invalid URL", e);
       }
     } else if (type.image.startsWith("env:")) {
       value = Expr.makeEnvImport(type.image.substring(4), mode, hash);
@@ -674,7 +675,7 @@ final class ParsingHelpers {
       try {
         value = Expr.makeLocalImport(Paths.get(type.image), mode, hash);
       } catch (java.nio.file.InvalidPathException e) {
-        System.out.println(e);
+        throw new ParsingFailure("Invalid path", e);
       }
     }
 

--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -197,11 +197,12 @@ TOKEN: {
     | ["\u0030"-"\u003b"] | ["\u0040"-"\u005a"] | ["\u0040"-"\u005a"] | ["\u005e"-"\u007a"]>
   | <#QUOTED_PATH_CHARACTER: ["\u0020"-"\u0021"] | ["\u0023"-"\u002e"] | ["\u0030"-"\u007f"] | <VALID_NON_ASCII>>
   | <#PATH_COMPONENT: "/" ((<PATH_CHARACTER>)+ | ("\"" (<QUOTED_PATH_CHARACTER>)+ "\""))>
+  | <#URL_PATH_COMPONENT: "/" ((<PATH_CHARACTER>)+)>
   | <#PATH: (<PATH_COMPONENT>)+>
   | <#PARENT_PATH: ".." <PATH>>
   | <#HERE_PATH: "." <PATH>>
   | <#HOME_PATH: "~" <PATH>>
-  | <#URL_PATH: (<PATH_COMPONENT> | ("/") <SEGMENT>)*>
+  | <#URL_PATH: (<URL_PATH_COMPONENT> | ("/") <SEGMENT>)*>
 }
 
 <WITHIN_DOUBLE_QUOTE> TOKEN: {

--- a/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
+++ b/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
@@ -4,6 +4,7 @@ import java.net.URI
 import java.nio.file.Paths
 
 import munit.{FunSuite, Ignore}
+import org.dhallj.core.DhallException.ParsingFailure
 import org.dhallj.core.Expr
 import org.dhallj.core.Expr.ImportMode
 
@@ -72,5 +73,9 @@ class DhallParserSuite extends FunSuite() {
     val expected = Expr.makeClasspathImport(Paths.get("/foo/bar.dhall"), ImportMode.RAW_TEXT, null)
 
     assert(DhallParser.parse("classpath:/foo/bar.dhall as Text") == expected)
+  }
+
+  test("fail on URLs with quoted paths") {
+    intercept[ParsingFailure](DhallParser.parse("https://example.com/foo/\"bar?baz\"?qux"))
   }
 }


### PR DESCRIPTION
Previously our grammar accepted URLs with quoted paths but then (silently) failed while creating an `Expr`. The grammar no longer accepts these (and there's a test to verify that), and I've changed the parser to fail fast on any other `URI` or `Path` parsing issues that could come up in the future.

I also added a note to the README explaining that we don't support this deprecated URL syntax.

I believe this should close #34—what do you think, @TimWSpence?