### PR TITLE
Ignore flaky Circe round-trip test

### DIFF
--- a/modules/circe/src/test/scala/org/dhallj/circe/CirceConverterSuite.scala
+++ b/modules/circe/src/test/scala/org/dhallj/circe/CirceConverterSuite.scala
@@ -9,7 +9,7 @@ import org.dhallj.core.Expr
 import org.dhallj.parser.DhallParser
 import org.scalacheck.Prop
 
-class JawnConverterSuite extends ScalaCheckSuite {
+class CirceConverterSuite extends ScalaCheckSuite {
   property("round-trip Json values through Dhall expressions") {
     // Shrinking gives us JSON object fields with empty keys.
     Prop.forAllNoShrink { (value: Json) =>

--- a/modules/circe/src/test/scala/org/dhallj/circe/CirceConverterSuite.scala
+++ b/modules/circe/src/test/scala/org/dhallj/circe/CirceConverterSuite.scala
@@ -3,14 +3,14 @@ package org.dhallj.circe
 import io.circe.Json
 import io.circe.syntax._
 import io.circe.testing.instances._
-import munit.ScalaCheckSuite
+import munit.{Ignore, ScalaCheckSuite}
 import org.dhallj.ast._
 import org.dhallj.core.Expr
 import org.dhallj.parser.DhallParser
 import org.scalacheck.Prop
 
 class CirceConverterSuite extends ScalaCheckSuite {
-  property("round-trip Json values through Dhall expressions") {
+  property("round-trip Json values through Dhall expressions".tag(Ignore)) {
     // Shrinking gives us JSON object fields with empty keys.
     Prop.forAllNoShrink { (value: Json) =>
       val cleanedJson = value.foldWith(JsonCleaner)


### PR DESCRIPTION
I think this is primarily an issue with the `Arbitrary` instance, but this test is failing maybe a quarter of build jobs, and it's pretty low-priority. Also the name of the test was wrong. I'll open an issue to make sure we investigate at some point.