### PR TITLE
Imports API

### DIFF
--- a/modules/core/src/main/java/org/dhallj/cbor/CBORException.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/CBORException.java
@@ -1,7 +1,0 @@
-package org.dhallj.cbor;
-
-public class CBORException extends RuntimeException {
-  CBORException(String message) {
-    super(message);
-  }
-}

--- a/modules/core/src/main/java/org/dhallj/cbor/CborException.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/CborException.java
@@ -1,0 +1,7 @@
+package org.dhallj.cbor;
+
+public class CborException extends RuntimeException {
+  CborException(String message) {
+    super(message);
+  }
+}

--- a/modules/core/src/main/java/org/dhallj/cbor/NullVisitor.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/NullVisitor.java
@@ -78,6 +78,6 @@ final class NullVisitor<R> implements Visitor<R> {
   }
 
   private R notExpected(String msg) {
-    throw new CBORException(String.format("%s not expected - expected null", msg));
+    throw new CborException(String.format("%s not expected - expected null", msg));
   }
 }

--- a/modules/core/src/main/java/org/dhallj/cbor/Reader.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Reader.java
@@ -29,11 +29,11 @@ public abstract class Reader {
       case MAP:
         return visitor.onMap(readMapStart(b));
       case SEMANTIC_TAG:
-        throw new CBORException("We should have skipped semantic tags");
+        throw new CborException("We should have skipped semantic tags");
       case PRIMITIVE:
         return readPrimitive(b, visitor);
       default:
-        throw new CBORException(String.format("Invalid CBOR major type %d", b));
+        throw new CborException(String.format("Invalid CBOR major type %d", b));
     }
   }
 
@@ -52,7 +52,7 @@ public abstract class Reader {
     skip55799();
     BigInteger result = readBigNum();
     if (result.compareTo(BigInteger.ZERO) < 0) {
-      throw new CBORException(String.format("%s is not a positive big num", result));
+      throw new CborException(String.format("%s is not a positive big num", result));
     } else {
       return result;
     }
@@ -78,10 +78,10 @@ public abstract class Reader {
         } else if (tag == 3) {
           return BigInteger.valueOf(-1).subtract(result);
         } else {
-          throw new CBORException(String.format("%d is not a valid tag for a bignum", tag));
+          throw new CborException(String.format("%d is not a valid tag for a bignum", tag));
         }
       default:
-        throw new CBORException(String.format("%d not a valid major type for an Unsigned Integer"));
+        throw new CborException(String.format("%d not a valid major type for an Unsigned Integer"));
     }
   }
 
@@ -94,7 +94,7 @@ public abstract class Reader {
       case PRIMITIVE:
         return readPrimitive(next, NullVisitor.instanceForString);
       default:
-        throw new CBORException("Next symbol is neither a text string or null");
+        throw new CborException("Next symbol is neither a text string or null");
     }
   }
 
@@ -107,7 +107,7 @@ public abstract class Reader {
       case PRIMITIVE:
         return readPrimitive(next, NullVisitor.instanceForByteArray);
       default:
-        throw new CBORException("Next symbol is neither a byte string or null");
+        throw new CborException("Next symbol is neither a byte string or null");
     }
   }
 
@@ -137,12 +137,12 @@ public abstract class Reader {
         AdditionalInfo info = AdditionalInfo.fromByte(next);
         BigInteger length = readBigInteger(info, next);
         if (length.compareTo(BigInteger.ZERO) < 0) {
-          throw new CBORException("Indefinite array not needed for Dhall");
+          throw new CborException("Indefinite array not needed for Dhall");
         } else {
           return length;
         }
       default:
-        throw new CBORException("Next symbol is not an array");
+        throw new CborException("Next symbol is not an array");
     }
   }
 
@@ -160,7 +160,7 @@ public abstract class Reader {
         }
         return entries;
       default:
-        throw new CBORException(
+        throw new CborException(
             String.format("Cannot read map - major type is %s", MajorType.fromByte(b)));
     }
   }
@@ -179,7 +179,7 @@ public abstract class Reader {
     AdditionalInfo info = AdditionalInfo.fromByte(b);
     BigInteger length = readBigInteger(info, b);
     if (length.compareTo(BigInteger.ZERO) < 0) {
-      throw new CBORException("Indefinite byte string not needed for Dhall");
+      throw new CborException("Indefinite byte string not needed for Dhall");
     } else {
       // We don't handle the case where the length is > Integer.MaxValue
       return this.read(length.intValue());
@@ -191,7 +191,7 @@ public abstract class Reader {
     BigInteger length = readBigInteger(info, b);
     if (length.compareTo(BigInteger.ZERO) < 0) {
       // Indefinite length - do we need this for Dhall?
-      throw new CBORException("Indefinite text string not needed for Dhall");
+      throw new CborException("Indefinite text string not needed for Dhall");
     } else {
       // We don't handle the case where the length is > Integer.MaxValue
       return new String(this.read(length.intValue()), Charset.forName("UTF-8"));
@@ -202,7 +202,7 @@ public abstract class Reader {
     AdditionalInfo info = AdditionalInfo.fromByte(b);
     BigInteger length = readBigInteger(info, b);
     if (length.compareTo(BigInteger.ZERO) < 0) {
-      throw new CBORException("Indefinite array not needed for Dhall");
+      throw new CborException("Indefinite array not needed for Dhall");
     } else {
       skip55799();
       byte next = read();
@@ -212,7 +212,7 @@ public abstract class Reader {
         case TEXT_STRING:
           return visitor.onVariableArray(length, readTextString(next));
         default:
-          throw new CBORException(
+          throw new CborException(
               String.format(
                   "Invalid start to CBOR-encoded Dhall expression %s",
                   MajorType.fromByte(b).toString()));
@@ -224,7 +224,7 @@ public abstract class Reader {
     AdditionalInfo info = AdditionalInfo.fromByte(b);
     BigInteger length = readBigInteger(info, b);
     if (length.compareTo(BigInteger.ZERO) < 0) {
-      throw new CBORException("Indefinite array not needed for Dhall");
+      throw new CborException("Indefinite array not needed for Dhall");
     } else {
       return length;
     }
@@ -233,7 +233,7 @@ public abstract class Reader {
   private final <R> R readPrimitive(byte b, Visitor<R> visitor) {
     int value = b & 31;
     if (0 <= value && value <= 19) {
-      throw new CBORException(String.format("Primitive %d is unassigned", value));
+      throw new CborException(String.format("Primitive %d is unassigned", value));
     } else if (value == 20) {
       return visitor.onFalse();
     } else if (value == 21) {
@@ -241,9 +241,9 @@ public abstract class Reader {
     } else if (value == 22) {
       return visitor.onNull();
     } else if (value == 23) {
-      throw new CBORException(String.format("Primitive %d is unassigned", value));
+      throw new CborException(String.format("Primitive %d is unassigned", value));
     } else if (value == 24) {
-      throw new CBORException("Simple value not needed for Dhall");
+      throw new CborException("Simple value not needed for Dhall");
     } else if (value == 25) {
       // https://github.com/c-rack/cbor-java/blob/master/src/main/java/co/nstant/in/cbor/decoder/HalfPrecisionFloatDecoder.java
       int bits = 0;
@@ -283,11 +283,11 @@ public abstract class Reader {
       }
       return visitor.onDoubleFloat(Double.longBitsToDouble(result));
     } else if (28 <= value && value <= 30) {
-      throw new CBORException(String.format("Primitive %d is unassigned", value));
+      throw new CborException(String.format("Primitive %d is unassigned", value));
     } else if (value == 31) {
-      throw new CBORException("Break stop code not needed for Dhall");
+      throw new CborException("Break stop code not needed for Dhall");
     } else {
-      throw new CBORException(String.format("Primitive %d is not valid", value));
+      throw new CborException(String.format("Primitive %d is not valid", value));
     }
   }
 
@@ -303,7 +303,7 @@ public abstract class Reader {
             BigInteger tag = readBigInteger(info, read()); // Now advance pointer
             int t = tag.intValue();
             if (t != 55799) {
-              throw new CBORException(String.format("Unrecognized CBOR semantic tag %d", t));
+              throw new CborException(String.format("Unrecognized CBOR semantic tag %d", t));
             } else {
               skip55799(); // Please tell me no encoders do this
             }
@@ -325,7 +325,7 @@ public abstract class Reader {
       case EIGHT_BYTES:
         return readBigInteger(8);
       case RESERVED:
-        throw new CBORException("Additional info RESERVED should not require reading a uintXX");
+        throw new CborException("Additional info RESERVED should not require reading a uintXX");
       case INDEFINITE:
         return BigInteger.valueOf(-1);
       default:

--- a/modules/core/src/main/java/org/dhallj/core/binary/CborDecodingVisitor.java
+++ b/modules/core/src/main/java/org/dhallj/core/binary/CborDecodingVisitor.java
@@ -20,11 +20,11 @@ import java.util.Map;
  * <p>Note that e.g. a negative integer by itself is an error, but a single float by itself is
  * allowed.
  */
-final class CBORDecodingVisitor implements Visitor<Expr> {
+final class CborDecodingVisitor implements Visitor<Expr> {
 
   private final Reader reader;
 
-  CBORDecodingVisitor(Reader reader) {
+  CborDecodingVisitor(Reader reader) {
     this.reader = reader;
   }
 

--- a/modules/core/src/main/java/org/dhallj/core/binary/Decode.java
+++ b/modules/core/src/main/java/org/dhallj/core/binary/Decode.java
@@ -7,7 +7,7 @@ public class Decode {
   public static final Expr decode(byte[] bytes) {
     Reader reader = new Reader.ByteArrayReader(bytes);
     // TODO check: if identifier then must be builtin using Expr.Constants.isBuiltInConstant
-    Expr e = reader.nextSymbol(new CBORDecodingVisitor(reader));
+    Expr e = reader.nextSymbol(new CborDecodingVisitor(reader));
     return e;
   }
 }

--- a/modules/imports/src/main/scala/org/dhallj/imports/CORSComplianceCheck.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/CORSComplianceCheck.scala
@@ -12,9 +12,9 @@ object CORSComplianceCheck {
 
   def apply[F[_]](parent: ImportContext, child: ImportContext, headers: Headers)(implicit F: Sync[F]): F[Unit] =
     parent match {
-      case Remote(uri, _) =>
+      case ImportContext.Remote(uri, _) =>
         child match {
-          case Remote(uri2, _) =>
+          case ImportContext.Remote(uri2, _) =>
             if (sameOrigin(uri, uri2))
               F.unit
             else

--- a/modules/imports/src/main/scala/org/dhallj/imports/Canonicalization.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/Canonicalization.scala
@@ -56,7 +56,7 @@ object Canonicalization {
       case _ => canonicalize(child)
     }
 
-  case class LocalFile(dirs: LocalDirs, filename: String) {
+  private case class LocalFile(dirs: LocalDirs, filename: String) {
     def toPath: Path = {
       def toPath(l: List[String]) = "/" + l.intercalate("/")
 
@@ -76,7 +76,7 @@ object Canonicalization {
     def canonicalize: LocalFile = LocalFile.canonicalize(this)
   }
 
-  object LocalFile {
+  private object LocalFile {
     def apply[F[_]](path: Path)(implicit F: Sync[F]): F[LocalFile] =
       path.iterator().asScala.toList.map(_.toString) match {
         case Nil => F.raiseError(new ResolutionFailure("This shouldn't happen - / can't import a dhall expression"))
@@ -89,7 +89,7 @@ object Canonicalization {
     def chain(lhs: LocalFile, rhs: LocalFile): LocalFile = LocalFile(LocalDirs.chain(lhs.dirs, rhs.dirs), rhs.filename)
   }
 
-  case class LocalDirs(ds: List[String]) {
+  private case class LocalDirs(ds: List[String]) {
     def isRelative = ds.nonEmpty && (ds.head == "." || ds.head == "..")
 
     def canonicalize: LocalDirs = LocalDirs.canonicalize(this)
@@ -97,7 +97,7 @@ object Canonicalization {
     def chain(other: LocalDirs): LocalDirs = LocalDirs.chain(this, other)
   }
 
-  object LocalDirs {
+  private object LocalDirs {
     def chain(lhs: LocalDirs, rhs: LocalDirs): LocalDirs = if (rhs.isRelative) LocalDirs(lhs.ds ++ rhs.ds) else rhs
 
     def canonicalize(d: LocalDirs): LocalDirs = d.ds match {

--- a/modules/imports/src/main/scala/org/dhallj/imports/Canonicalization.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/Canonicalization.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Path, Paths}
 import cats.implicits._
 import cats.effect.Sync
 import org.dhallj.core.DhallException.ResolutionFailure
-import org.dhallj.imports.ResolveImportsVisitor._
+import org.dhallj.imports.ImportContext._
 
 import scala.collection.JavaConverters._
 

--- a/modules/imports/src/main/scala/org/dhallj/imports/CorsComplianceCheck.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/CorsComplianceCheck.scala
@@ -8,7 +8,7 @@ import org.dhallj.imports.ResolveImportsVisitor._
 import org.http4s.Headers
 import org.http4s.headers.`Access-Control-Allow-Origin`
 
-object CORSComplianceCheck {
+object CorsComplianceCheck {
 
   def apply[F[_]](parent: ImportContext, child: ImportContext, headers: Headers)(implicit F: Sync[F]): F[Unit] =
     parent match {

--- a/modules/imports/src/main/scala/org/dhallj/imports/ImportContext.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ImportContext.scala
@@ -1,0 +1,15 @@
+package org.dhallj.imports
+
+import java.net.URI
+import java.nio.file.Path
+import org.dhallj.core.Expr
+
+sealed abstract class ImportContext extends Product with Serializable
+
+object ImportContext {
+  case object Missing extends ImportContext
+  case class Env(value: String) extends ImportContext
+  case class Local(absolutePath: Path) extends ImportContext
+  case class Classpath(absolutePath: Path) extends ImportContext
+  case class Remote(url: URI, using: Expr) extends ImportContext
+}

--- a/modules/imports/src/main/scala/org/dhallj/imports/ReferentialSanityCheck.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ReferentialSanityCheck.scala
@@ -7,29 +7,29 @@ import org.dhallj.imports.ResolveImportsVisitor._
 object ReferentialSanityCheck {
 
   def apply[F[_]](parent: ImportContext, child: ImportContext)(implicit F: Sync[F]): F[Unit] = parent match {
-    case Remote(uri, _) =>
+    case ImportContext.Remote(uri, _) =>
       child match {
-        case Remote(_, _) => F.unit
-        case Missing      => F.unit
-        case Local(path) =>
+        case ImportContext.Remote(_, _) => F.unit
+        case ImportContext.Missing      => F.unit
+        case ImportContext.Local(path) =>
           F.raiseError(
             new ResolutionFailure(
               "Referential sanity violation - remote import $uri cannot reference local import $path"
             )
           )
-        case Classpath(path) =>
+        case ImportContext.Classpath(path) =>
           F.raiseError(
             new ResolutionFailure(
               "Referential sanity violation - remote import $uri cannot reference classpath import $path"
             )
           )
-        case Env(v) =>
+        case ImportContext.Env(v) =>
           F.raiseError(
             new ResolutionFailure("Referential sanity violation - remote import $uri cannot reference env import $v")
           )
       }
-    case Missing => F.raiseError(new ResolutionFailure(s"Missing import cannot reference import $child"))
-    case _       => F.unit
+    case ImportContext.Missing => F.raiseError(new ResolutionFailure(s"Missing import cannot reference import $child"))
+    case _                     => F.unit
   }
 
 }

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImports.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImports.scala
@@ -1,0 +1,26 @@
+package org.dhallj.imports
+
+import cats.effect.Sync
+import org.dhallj.core.Expr
+import org.http4s.client.Client
+
+object ResolveImports {
+  def apply[F[_] <: AnyRef](expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
+    F.flatMap(ResolveImportsVisitor[F])(expr.accept(_))
+
+  def apply[F[_] <: AnyRef](
+    semanticCache: ImportCache[F],
+    semiSemanticCache: ImportCache[F]
+  )(expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
+    expr.accept(ResolveImportsVisitor[F](semanticCache, semiSemanticCache))
+
+  def apply[F[_] <: AnyRef](
+    semanticCache: ImportCache[F]
+  )(expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
+    expr.accept(ResolveImportsVisitor[F](semanticCache, new ImportCache.NoopImportCache))
+
+  final class Ops(val expr: Expr) extends AnyVal {
+    def resolveImports[F[_] <: AnyRef](implicit Client: Client[F], F: Sync[F]): F[Expr] =
+      ResolveImports.apply[F](expr)
+  }
+}

--- a/modules/imports/src/main/scala/org/dhallj/imports/package.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/package.scala
@@ -1,15 +1,7 @@
 package org.dhallj
 
-import _root_.cats.effect.Sync
-import _root_.cats.implicits._
 import org.dhallj.core.Expr
-import org.http4s.client._
 
 package object imports {
-
-  implicit class ResolveImports(e: Expr) {
-    def resolveImports[F[_] <: AnyRef](implicit Client: Client[F], F: Sync[F]): F[Expr] =
-      ResolveImportsVisitor.mkVisitor >>= (v => e.accept(v))
-  }
-
+  implicit def toResolveImportOps(expr: Expr): ResolveImports.Ops = new ResolveImports.Ops(expr)
 }

--- a/modules/imports/src/test/scala/org/dhallj/imports/CORSComplianceCheckSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/CORSComplianceCheckSuite.scala
@@ -5,7 +5,7 @@ import java.nio.file.Paths
 
 import cats.effect.IO
 import munit.FunSuite
-import org.dhallj.imports.ResolveImportsVisitor._
+import org.dhallj.imports.ImportContext._
 import org.http4s.{Header, Headers}
 
 class CORSComplianceCheckSuite extends FunSuite {

--- a/modules/imports/src/test/scala/org/dhallj/imports/CanonicalizationSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/CanonicalizationSuite.scala
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 import cats.effect.IO
 import munit.FunSuite
 import org.dhallj.imports.Canonicalization._
-import org.dhallj.imports.ResolveImportsVisitor._
+import org.dhallj.imports.ImportContext._
 import org.dhallj.parser.DhallParser.parse
 
 /**

--- a/modules/imports/src/test/scala/org/dhallj/imports/CanonicalizationSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/CanonicalizationSuite.scala
@@ -5,7 +5,7 @@ import java.nio.file.Paths
 
 import cats.effect.IO
 import munit.FunSuite
-import org.dhallj.imports.Canonicalization._
+import org.dhallj.imports.Canonicalization.canonicalize
 import org.dhallj.imports.ImportContext._
 import org.dhallj.parser.DhallParser.parse
 

--- a/modules/imports/src/test/scala/org/dhallj/imports/CorsComplianceCheckSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/CorsComplianceCheckSuite.scala
@@ -8,7 +8,7 @@ import munit.FunSuite
 import org.dhallj.imports.ImportContext._
 import org.http4s.{Header, Headers}
 
-class CORSComplianceCheckSuite extends FunSuite {
+class CorsComplianceCheckSuite extends FunSuite {
 
   val fooOrigin = new URI("http://foo.org/foo.dhall")
   val fooOrigin8080 = new URI("http://foo.org:8080/foo.dhall")
@@ -18,54 +18,54 @@ class CORSComplianceCheckSuite extends FunSuite {
   val localPath = Paths.get("/foo/bar.dhall")
 
   test("Remote - same origin") {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null), Remote(fooOrigin2, null), Headers.empty).unsafeRunSync()
+    CorsComplianceCheck[IO](Remote(fooOrigin, null), Remote(fooOrigin2, null), Headers.empty).unsafeRunSync()
   }
 
   test("Remote - different origin, allow *") {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null),
+    CorsComplianceCheck[IO](Remote(fooOrigin, null),
                             Remote(barOrigin, null),
                             Headers.of(Header("Access-Control-Allow-Origin", "*"))).unsafeRunSync()
   }
 
   test("Remote - different origin, allow parent authority") {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null),
+    CorsComplianceCheck[IO](Remote(fooOrigin, null),
                             Remote(barOrigin, null),
                             Headers.of(Header("Access-Control-Allow-Origin", "http://foo.org"))).unsafeRunSync()
   }
 
   test("Remote - different origin".fail) {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null), Remote(barOrigin, null), Headers.empty).unsafeRunSync()
+    CorsComplianceCheck[IO](Remote(fooOrigin, null), Remote(barOrigin, null), Headers.empty).unsafeRunSync()
   }
 
   test("Remote - different origin, cors parent different authority".fail) {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null),
+    CorsComplianceCheck[IO](Remote(fooOrigin, null),
                             Remote(barOrigin, null),
                             Headers.of(Header("Access-Control-Allow-Origin", "http://bar.org"))).unsafeRunSync()
   }
 
   test("Remote - different origin, cors parent different scheme".fail) {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null),
+    CorsComplianceCheck[IO](Remote(fooOrigin, null),
                             Remote(barOrigin, null),
                             Headers.of(Header("Access-Control-Allow-Origin", "https://foo.org"))).unsafeRunSync()
   }
 
   test("Remote - different origin, cors parent different port".fail) {
-    CORSComplianceCheck[IO](Remote(fooOrigin, null),
+    CorsComplianceCheck[IO](Remote(fooOrigin, null),
                             Remote(barOrigin, null),
                             Headers.of(Header("Access-Control-Allow-Origin", "http://foo.org:8080"))).unsafeRunSync()
   }
 
   test("Remote - different origin, cors parent different port 2".fail) {
-    CORSComplianceCheck[IO](Remote(fooOrigin8080, null),
+    CorsComplianceCheck[IO](Remote(fooOrigin8080, null),
                             Remote(barOrigin, null),
                             Headers.of(Header("Access-Control-Allow-Origin", "http://foo.org"))).unsafeRunSync()
   }
 
   test("Local") {
-    CORSComplianceCheck[IO](Local(localPath), Remote(fooOrigin2, null), Headers.empty).unsafeRunSync()
+    CorsComplianceCheck[IO](Local(localPath), Remote(fooOrigin2, null), Headers.empty).unsafeRunSync()
   }
 
   test("Env") {
-    CORSComplianceCheck[IO](Env("foo"), Remote(fooOrigin2, null), Headers.empty).unsafeRunSync()
+    CorsComplianceCheck[IO](Env("foo"), Remote(fooOrigin2, null), Headers.empty).unsafeRunSync()
   }
 }

--- a/modules/imports/src/test/scala/org/dhallj/imports/ImportCacheSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/ImportCacheSuite.scala
@@ -5,15 +5,14 @@ import java.nio.file.{Files, Path, Paths}
 import cats.effect.IO
 import cats.implicits._
 import munit.FunSuite
-import org.dhallj.imports.Caching.{ImportsCache, ImportsCacheImpl}
 import scala.reflect.io.Directory
 
 class CachingSuite extends FunSuite {
 
-  val rootDir = new FunFixture[(ImportsCache[IO], Path)](
+  val rootDir = new FunFixture[(ImportCache[IO], Path)](
     setup = { test =>
       val rootDir = Files.createTempDirectory(test.name).resolve("dhall")
-      Caching.mkImportsCache[IO](rootDir).unsafeRunSync.get -> rootDir
+      ImportCache[IO](rootDir).unsafeRunSync.get -> rootDir
     },
     teardown = {
       case (_, rootDir) =>

--- a/modules/imports/src/test/scala/org/dhallj/imports/ImportResolutionSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/ImportResolutionSuite.scala
@@ -8,7 +8,6 @@ import cats.implicits._
 import munit.FunSuite
 import org.dhallj.core.Expr
 import org.dhallj.core.binary.Decode
-import org.dhallj.imports.Caching.{ImportsCache, NoopImportsCache}
 import org.dhallj.parser.DhallParser.parse
 import org.http4s.client._
 import org.http4s.client.blaze._
@@ -222,14 +221,14 @@ class ImportResolutionSuite extends FunSuite {
       e.resolveImports[IO].map(_.normalize)
     }.unsafeRunSync
 
-  private def resolveWithCustomCache(cache: ImportsCache[IO], e: Expr): IO[Expr] =
+  private def resolveWithCustomCache(cache: ImportCache[IO], e: Expr): IO[Expr] =
     client.use { c =>
       implicit val http: Client[IO] = c
 
-      e.accept(ResolveImportsVisitor.mkVisitor(cache, NoopImportsCache[IO]))
+      e.accept(ResolveImportsVisitor[IO](cache))
     }
 
-  private case class InMemoryCache() extends ImportsCache[IO] {
+  private case class InMemoryCache() extends ImportCache[IO] {
 
     private val store: Ref[IO, Map[List[Byte], Array[Byte]]] = Ref.unsafe(Map.empty)
 

--- a/modules/imports/src/test/scala/org/dhallj/imports/ReferentialSanityCheckSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/ReferentialSanityCheckSuite.scala
@@ -5,7 +5,7 @@ import java.nio.file.Paths
 
 import cats.effect.IO
 import munit.FunSuite
-import org.dhallj.imports.ResolveImportsVisitor._
+import org.dhallj.imports.ImportContext._
 
 class ReferentialSanityCheckSuite extends FunSuite {
 

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
@@ -8,8 +8,7 @@ import org.dhallj.core.binary.Decode.decode
 import org.dhallj.imports.mini.Resolver
 import org.dhallj.parser.DhallParser
 
-import org.dhallj.imports._
-import org.dhallj.imports.Caching._
+import org.dhallj.imports.{ImportCache, ResolveImports}
 import org.http4s.client._
 import org.http4s.client.blaze._
 
@@ -60,7 +59,7 @@ trait CachedResolvingInput extends Input[Expr] {
       implicit val cs: ContextShift[IO] = IO.contextShift(global)
       BlazeClientBuilder[IO](global).resource.use { client =>
         implicit val c: Client[IO] = client
-        parsed.accept(ResolveImportsVisitor.mkVisitor[IO].unsafeRunSync)
+        ResolveImports(parsed)
       }.unsafeRunSync
     }
   }
@@ -77,7 +76,7 @@ trait ResolvingInput extends Input[Expr] {
       implicit val cs: ContextShift[IO] = IO.contextShift(global)
       BlazeClientBuilder[IO](global).resource.use { client =>
         implicit val c: Client[IO] = client
-        parsed.accept(ResolveImportsVisitor.mkVisitor(NoopImportsCache[IO], NoopImportsCache[IO]))
+        ResolveImports(new ImportCache.NoopImportCache[IO], new ImportCache.NoopImportCache[IO])(parsed)
       }.unsafeRunSync
     }
   }


### PR DESCRIPTION
This PR includes a few API changes for the imports module that I thought we could get in before 0.2.0, primarily with the goal of minimizing our binary compatibility obligations in future releases.

I've promoted a couple of types that were previously defined in package-private objects but were also exposed in public method signatures in other places, and which felt like they should be in the public API (given usage in tests, etc.):

* `ResolveImportsVisitor.ImportContext` is now `ImportContext`.
* `Caching.ImportsCache` is now `ImportCache` (I've depluralized it for consistency).

I've made a few things that were previously case classes (like `ResolveImportsVisitor` and `NoopImportCache`) not case classes, since they don't really need to be, and since case classes with type class constraints are kind of weird (e.g. it's not really clear what equality should mean for two `ResolveImportsVisitor` values with different `F`s or different clients or `Sync` instances).

I've added a new `ResolveImports` object that provides a non-enrichment-method-based version of the  top-level API, providing two methods (essentially `Expr => F[Expr]` and `(ImportCache, Expr) => F[Expr]`). This allows us to avoid using `ResolveImportsVisitor` directly in tests, which feels a little better to me. I've added an `Ops` value class for the `resolveImports` enrichment method there (instead of an implicit class in the package object), since this keeps similar concerns in the same place, and is closer to the pattern used by Cats, etc.

I've made `ResolveImportsVisitor` and a couple of other things properly private instead of package-private, since this frees them up from binary compatibility concerns (since Scala's access modifiers are a terrible mess and package privacy is just public from the JVM's point of view).

I've also changed `CORSComplianceCheck` to `CorsComplianceCheck` for consistency with most other acronym-including names in the project (like `JsonConverter`, `YamlConverter`, etc.; I also went ahead and changed a couple of instances of `CBORX` to `CborX` here as well).