### PR TITLE
Encode Doubles as half-floats when possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val snakeYamlVersion = "1.26"
 val http4sVersion = "0.21.3"
 
 val testDependencies = Seq(
+  "co.nstant.in" % "cbor" % "0.9",
   "org.scalacheck" %% "scalacheck" % scalaCheckVersion,
   "org.scalameta" %% "munit" % munitVersion,
   "org.scalameta" %% "munit-scalacheck" % munitVersion
@@ -22,6 +23,7 @@ val http4sDependencies = Seq(
   "org.typelevel" %% "cats-effect" % "2.1.2",
   "org.http4s" %% "http4s-client" % http4sVersion
 )
+
 val http4sBlazeClient =
   "org.http4s" %% "http4s-blaze-client" % http4sVersion
 

--- a/modules/core/src/main/java/org/dhallj/cbor/HalfFloat.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/HalfFloat.java
@@ -1,0 +1,57 @@
+package org.dhallj.cbor;
+
+/**
+ * Conversions between 16 and 32-bit floating point numbers.
+ *
+ * @see <a href="https://stackoverflow.com/a/6162687/334519">this Stack Overflow answer</a>
+ */
+public final class HalfFloat {
+  public static final int fromFloat(float asFloat) {
+    int bits = Float.floatToIntBits(asFloat);
+    int sign = bits >>> 16 & 0x8000; // sign only
+    int value = (bits & 0x7fffffff) + 0x1000; // rounded value
+
+    if (value >= 0x47800000) // might be or become NaN/Inf
+    { // avoid Inf due to rounding
+
+      if (value < 0x7f800000) // was value but too large
+      return sign | 0x7c00; // make it +/-Inf
+      return sign
+          | 0x7c00
+          | // remains +/-Inf or NaN
+          (bits & 0x007fffff) >>> 13; // keep NaN (and Inf) bits
+    }
+    if (value >= 0x38800000) { // remains normalized value
+      return sign | value - 0x38000000 >>> 13; // exp - 127 + 15
+    }
+    if (value < 0x33000000) { // too small for subnormal
+      return sign; // becomes +/-0
+    }
+    value = (bits & 0x7fffffff) >>> 23; // tmp exp for subnormal calc
+
+    return sign
+        | ((bits & 0x7fffff | 0x800000) // add subnormal bit
+                + (0x800000 >>> value - 102) // round depending on cut off
+            >>> 126 - value); // div by 2^(1-(exp-127+15)) and >> 13 | exp=0
+  }
+
+  public static final float toFloat(int bits) {
+    int mant = bits & 0x03ff; // 10 bits mantissa
+    int exp = bits & 0x7c00; // 5 bits exponent
+    if (exp == 0x7c00) { // NaN/Inf
+      exp = 0x3fc00; // -> NaN/Inf
+    } else if (exp != 0) { // normalized value
+      exp += 0x1c000; // exp - 15 + 127
+    } else if (mant != 0) { // && exp==0 -> subnormal
+      exp = 0x1c400; // make it normal
+      do {
+        mant <<= 1; // mantissa * 2
+        exp -= 0x400; // decrease exp by 1
+      } while ((mant & 0x400) == 0); // while not normal
+      mant &= 0x3ff; // discard subnormal bit
+    } // else +/-0 -> +/-0
+    return Float.intBitsToFloat( // combine all parts
+        (bits & 0x8000) << 16 // sign  << ( 31 - 15 )
+            | (exp | mant) << 13); // value << ( 23 - 10 )
+  }
+}

--- a/modules/core/src/main/java/org/dhallj/cbor/Reader.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Reader.java
@@ -230,6 +230,20 @@ public abstract class Reader {
     }
   }
 
+  public static final float intBitsToFloat16(int bits) {
+    int s = (bits & 0x8000) >> 15;
+    int e = (bits & 0x7C00) >> 10;
+    int f = bits & 0x03FF;
+
+    if (e == 0) {
+      return (float) ((s != 0 ? -1 : 1) * Math.pow(2, -14) * (f / Math.pow(2, 10)));
+    } else if (e == 0x1F) {
+      return f != 0 ? Float.NaN : (s != 0 ? -1 : 1) * Float.POSITIVE_INFINITY;
+    }
+
+    return (float) ((s != 0 ? -1 : 1) * Math.pow(2, e - 15) * (1 + f / Math.pow(2, 10)));
+  }
+
   private final <R> R readPrimitive(byte b, Visitor<R> visitor) {
     int value = b & 31;
     if (0 <= value && value <= 19) {
@@ -253,19 +267,7 @@ public abstract class Reader {
         bits |= next;
       }
 
-      int s = (bits & 0x8000) >> 15;
-      int e = (bits & 0x7C00) >> 10;
-      int f = bits & 0x03FF;
-
-      float result = 0;
-      if (e == 0) {
-        result = (float) ((s != 0 ? -1 : 1) * Math.pow(2, -14) * (f / Math.pow(2, 10)));
-      } else if (e == 0x1F) {
-        result = f != 0 ? Float.NaN : (s != 0 ? -1 : 1) * Float.POSITIVE_INFINITY;
-      } else {
-        result = (float) ((s != 0 ? -1 : 1) * Math.pow(2, e - 15) * (1 + f / Math.pow(2, 10)));
-      }
-      return visitor.onHalfFloat(result);
+      return visitor.onHalfFloat(intBitsToFloat16(bits));
     } else if (value == 26) {
       int result = 0;
       for (int i = 0; i < 4; i++) {

--- a/modules/core/src/main/java/org/dhallj/cbor/Reader.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Reader.java
@@ -230,20 +230,6 @@ public abstract class Reader {
     }
   }
 
-  public static final float intBitsToFloat16(int bits) {
-    int s = (bits & 0x8000) >> 15;
-    int e = (bits & 0x7C00) >> 10;
-    int f = bits & 0x03FF;
-
-    if (e == 0) {
-      return (float) ((s != 0 ? -1 : 1) * Math.pow(2, -14) * (f / Math.pow(2, 10)));
-    } else if (e == 0x1F) {
-      return f != 0 ? Float.NaN : (s != 0 ? -1 : 1) * Float.POSITIVE_INFINITY;
-    }
-
-    return (float) ((s != 0 ? -1 : 1) * Math.pow(2, e - 15) * (1 + f / Math.pow(2, 10)));
-  }
-
   private final <R> R readPrimitive(byte b, Visitor<R> visitor) {
     int value = b & 31;
     if (0 <= value && value <= 19) {
@@ -267,7 +253,7 @@ public abstract class Reader {
         bits |= next;
       }
 
-      return visitor.onHalfFloat(intBitsToFloat16(bits));
+      return visitor.onHalfFloat(HalfFloat.toFloat(bits));
     } else if (value == 26) {
       int result = 0;
       for (int i = 0; i < 4; i++) {

--- a/modules/core/src/main/java/org/dhallj/cbor/Writer.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Writer.java
@@ -125,6 +125,26 @@ public abstract class Writer {
     this.write(bytes);
   }
 
+  // See https://stackoverflow.com/a/6162687/334519.
+  public static final int float16ToIntBits(float asFloat) {
+    int bits = Float.floatToIntBits(asFloat);
+    int sign = bits >>> 16 & 0x8000; // sign only
+    int value = (bits & 0x7fffffff) + 0x1000; // rounded value
+
+    if (value >= 0x38800000) { // remains normalized value
+      return sign | value - 0x38000000 >>> 13; // exp - 127 + 15
+    }
+    if (value < 0x33000000) { // too small for subnormal
+      return sign; // becomes +/-0
+    }
+    value = (bits & 0x7fffffff) >>> 23; // tmp exp for subnormal calc
+
+    return sign
+        | ((bits & 0x7fffff | 0x800000) // add subnormal bit
+                + (0x800000 >>> value - 102) // round depending on cut off
+            >>> 126 - value); // div by 2^(1-(exp-127+15)) and >> 13 | exp=0
+  }
+
   public final void writeDouble(double value) {
     int base = MajorType.PRIMITIVE.value << 5;
 
@@ -144,13 +164,23 @@ public abstract class Writer {
     } else {
       float asFloat = (float) value;
       if (value == (double) asFloat) {
-        int bits = Float.floatToRawIntBits(asFloat);
-        this.write(
-            (byte) (base | AdditionalInfo.FOUR_BYTES.value),
-            (byte) ((bits >> 24) & 0xff),
-            (byte) ((bits >> 16) & 0xff),
-            (byte) ((bits >> 8) & 0xff),
-            (byte) ((bits >> 0) & 0xff));
+        int asFloat16Bits = float16ToIntBits(asFloat);
+
+        if (Reader.intBitsToFloat16(asFloat16Bits) == asFloat) {
+          this.write(
+              (byte) (base | AdditionalInfo.TWO_BYTES.value),
+              (byte) ((asFloat16Bits >> 8) & 0xff),
+              (byte) ((asFloat16Bits >> 0) & 0xff));
+        } else {
+
+          int bits = Float.floatToRawIntBits(asFloat);
+          this.write(
+              (byte) (base | AdditionalInfo.FOUR_BYTES.value),
+              (byte) ((bits >> 24) & 0xff),
+              (byte) ((bits >> 16) & 0xff),
+              (byte) ((bits >> 8) & 0xff),
+              (byte) ((bits >> 0) & 0xff));
+        }
       } else {
 
         long bits = Double.doubleToRawLongBits(value);

--- a/modules/core/src/test/java/org/dhallj/cbor/CborSuite.scala
+++ b/modules/core/src/test/java/org/dhallj/cbor/CborSuite.scala
@@ -1,0 +1,63 @@
+package org.dhallj.cbor
+
+import co.nstant.in.cbor.{CborBuilder, CborEncoder}
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop
+
+class CborSuite extends ScalaCheckSuite {
+  def roundTripDouble(value: Double): Option[Double] = {
+    val writer = new Writer.ByteArrayWriter()
+    writer.writeDouble(value)
+
+    val bytes = writer.getBytes
+    val reader = new Reader.ByteArrayReader(bytes)
+    reader.nextSymbol(DoubleValueVisitor)
+  }
+
+  def encodeDoubleWithCborJava(value: Double): Array[Byte] = {
+    val stream = new ByteArrayOutputStream()
+    new CborEncoder(stream).encode(new CborBuilder().add(value).build())
+
+    return stream.toByteArray
+  }
+
+  property("Writer and Reader should round-trip doubles") {
+    Prop.forAll((value: Double) => roundTripDouble(value) == Some(value))
+  }
+
+  property("Writer should agree with cbor-java") {
+    Prop.forAll { (value: Double) =>
+      val writer = new Writer.ByteArrayWriter()
+      writer.writeDouble(value)
+
+      writer.getBytes.sameElements(encodeDoubleWithCborJava(value))
+    }
+  }
+
+  test("Writer and Reader should round-trip special-case doubles") {
+    assertEquals(roundTripDouble(0.0), Some(0.0))
+    assertEquals(roundTripDouble(-0.0), Some(-0.0))
+    assertEquals(roundTripDouble(Double.PositiveInfinity), Some(Double.PositiveInfinity))
+    assertEquals(roundTripDouble(Double.NegativeInfinity), Some(Double.NegativeInfinity))
+    assert(roundTripDouble(Double.NaN).exists(_.isNaN))
+  }
+
+  object DoubleValueVisitor extends Visitor[Option[Double]] {
+    def onUnsignedInteger(value: BigInteger): Option[Double] = None
+    def onNegativeInteger(value: BigInteger): Option[Double] = None
+    def onByteString(value: Array[Byte]): Option[Double] = None
+    def onTextString(value: String): Option[Double] = None
+    def onVariableArray(length: BigInteger, name: String): Option[Double] = None
+    def onArray(length: BigInteger, tagI: BigInteger): Option[Double] = None
+    def onMap(size: BigInteger): Option[Double] = None
+    def onFalse: Option[Double] = None
+    def onTrue: Option[Double] = None
+    def onNull: Option[Double] = None
+    def onHalfFloat(value: Float): Option[Double] = Some(value.toDouble)
+    def onSingleFloat(value: Float): Option[Double] = Some(value.toDouble)
+    def onDoubleFloat(value: Double): Option[Double] = Some(value)
+    def onTag: Option[Double] = None
+  }
+}

--- a/modules/core/src/test/java/org/dhallj/cbor/HalfFloatSuite.scala
+++ b/modules/core/src/test/java/org/dhallj/cbor/HalfFloatSuite.scala
@@ -1,0 +1,35 @@
+package org.dhallj.cbor
+
+import munit.FunSuite
+import org.scalacheck.Prop
+
+class HalfFloatSuite extends FunSuite {
+  def roundTripInt(x: Int): Int =
+    HalfFloat.toFloat(HalfFloat.fromFloat(x.toFloat)).toInt
+
+  test("HalfFloat conversions round-trip integers with abs <= 2048") {
+    0.to(2048).foreach { x =>
+      assertEquals(roundTripInt(x), x)
+      assertEquals(roundTripInt(-x), -x)
+    }
+  }
+
+  test("HalfFloat conversions round-trip even integers with abs <= 4096") {
+    1.to(1024).foreach { x =>
+      assertEquals(roundTripInt((x * 2) + 2048), (x * 2) + 2048)
+      assertEquals(roundTripInt(-((x * 2) + 2048)), -((x * 2) + 2048))
+      assertEquals(roundTripInt((x * 2) + 2048 - 1), (x * 2) + 2048)
+      assertEquals(roundTripInt(-((x * 2) + 2048 - 1)), -((x * 2) + 2048))
+    }
+  }
+
+  test("HalfFloat conversions round-trip through float for all values") {
+    0.until(1 << 16).foreach { x =>
+      val asFloat = HalfFloat.toFloat(x)
+
+      if (!asFloat.isNaN) {
+        assertEquals(HalfFloat.fromFloat(asFloat), x)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a quick sketch of what would be needed to support [this proposed change to the spec](https://github.com/dhall-lang/dhall-lang/pull/958). It's not quite as trivial as I expected, but it's not too bad either. The only interesting new code is borrowed from [this Stack Overflow answer](https://stackoverflow.com/a/6162687/334519), which the author has put into the public domain.

We can probably remove the special cases for negative zero and the NaNs and infinities now, and definitely should before merging this PR. I've just thrown put this branch together as a quick proof-of-concept to show roughly what the proposed change would require.

As a side note, we should probably change the `intBitsToFloat16` in our current code to use that side of the conversion from [the same Stack Overflow answer](https://stackoverflow.com/a/6162687/334519), instead of a version of the code that [cbor-java](https://github.com/c-rack/cbor-java/blob/master/src/main/java/co/nstant/in/cbor/encoder/HalfPrecisionFloatEncoder.java) uses, which comes from [this other Stack Overflow answer](https://stackoverflow.com/a/5684578/334519) that doesn't seem quite as trustworthy.

This will obviously need a lot more testing, but it won't be too hard to test fairly comprehensively (we might as well enumerate all possible half-float values in our tests).

Update: rebased on branch from #48, so all tests pass now. ~~Note that one normalization test (`UnsaturatedBuiltins`) is currently failing on this branch, but that's only because we haven't changed our implementation to reflect [this other new spec change](https://github.com/dhall-lang/dhall-lang/pull/950) yet. The relevant acceptance tests are passing.~~