### PR TITLE
Fix normalization of partially-saturated folds

### DIFF
--- a/modules/core/src/main/java/org/dhallj/core/normalization/BetaNormalizeApplication.java
+++ b/modules/core/src/main/java/org/dhallj/core/normalization/BetaNormalizeApplication.java
@@ -436,7 +436,8 @@ final class BetaNormalizeApplication {
 
         Expr tail;
         if (listArg.size() == 1) {
-          tail = Expr.makeEmptyListLiteral(newArgs.get(0));
+          tail =
+              Expr.makeEmptyListLiteral(Expr.makeApplication(Expr.Constants.LIST, newArgs.get(0)));
 
         } else {
           List<Expr> listArgTail = new ArrayList<>(listArg);
@@ -474,7 +475,7 @@ final class BetaNormalizeApplication {
       } else if (args.size() == 3) {
         return Expr.makeLambda(
             "cons",
-            Expr.makePi(newArgs.get(2).increment("cons"), newArgs.get(2).increment("cons")),
+            Expr.makePi(newArgs.get(0), Expr.makePi(newArgs.get(2), newArgs.get(2))),
             Expr.makeLambda("nil", newArgs.get(2).increment("cons"), applied));
       } else if (args.size() == 4) {
         return Expr.makeLambda("nil", newArgs.get(2).increment("cons"), applied);
@@ -532,7 +533,7 @@ final class BetaNormalizeApplication {
       } else if (args.size() == 3) {
         return Expr.makeLambda(
             "some",
-            Expr.makePi(newArgs.get(2).increment("some"), newArgs.get(2).increment("some")),
+            Expr.makePi(newArgs.get(2), newArgs.get(2)),
             Expr.makeLambda("none", newArgs.get(2).increment("some"), applied));
       } else if (args.size() == 4) {
         return Expr.makeLambda("none", newArgs.get(2).increment("some"), applied);


### PR DESCRIPTION
Noticed a couple of minor bugs while putting together a PR to remove this code, which was a temporary fix to emulate a bug in the Haskell implementation.

I don't want to actually remove this code until there's a new dhall-haskell release with the fix there, so I'm fixing the bug here for now.

The issue is pretty minor, and I think should only affect cases where you try to type-check a normalized expression with a partially-applied fold:  

```scala
scala> import org.dhallj.syntax._
import org.dhallj.syntax._

scala> "List/fold Natural [1] Natural".parseExpr.flatMap(_.normalize.typeCheck)
res0: scala.util.Either[org.dhallj.core.DhallException,org.dhallj.core.Expr] = Left(org.dhallj.core.typechecking.TypeCheckFailure: Can't apply Natural)
```

After this change:
```scala
scala> import org.dhallj.syntax._
import org.dhallj.syntax._

scala> "List/fold Natural [1] Natural".parseExpr.flatMap(_.normalize.typeCheck)
res0: scala.util.Either[org.dhallj.core.DhallException,org.dhallj.core.Expr] = Right(∀(cons : (Natural → Natural → Natural)) → ∀(nil : Natural) → Natural)
```

Thankfully this whole terrible hack will be gone soon!