### PR TITLE
Implement Dhall Haskell's semi-semantic import caching

### DIFF
--- a/modules/imports/src/main/scala/org/dhallj/imports/Caching.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/Caching.scala
@@ -54,13 +54,13 @@ private[dhallj] object Caching {
       perms <- F.delay(Files.isReadable(rootDir) && Files.isWritable(rootDir))
     } yield (if (perms) Some(new ImportsCacheImpl[F](rootDir)) else None)
 
-  def mkImportsCache[F[_] <: AnyRef](implicit F: Sync[F]): F[ImportsCache[F]] = {
+  def mkImportsCache[F[_] <: AnyRef](cacheName: String)(implicit F: Sync[F]): F[ImportsCache[F]] = {
     def makeCacheFromEnvVar(env: String, relativePath: String): F[Option[ImportsCache[F]]] =
       for {
         envValO <- F.delay(sys.env.get(env))
         cache <- envValO.fold(F.pure(Option.empty[ImportsCache[F]]))(envVal =>
           for {
-            rootDir <- F.pure(Paths.get(envVal, relativePath, "dhall"))
+            rootDir <- F.pure(Paths.get(envVal, relativePath, cacheName))
             c <- mkImportsCache(rootDir)
           } yield c
         )

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
@@ -54,6 +54,42 @@ private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](cache: ImportsC
     onImport(Missing, mode, hash)
 
   private def onImport(i: ImportContext, mode: Expr.ImportMode, hash: Array[Byte]): F[Expr] = {
+
+    //TODO replicate Dhall Haskell flow
+    //Compute chain
+    //Referential sanity check
+    //Check cyclic imports
+    //Resolve import - results in fully resolved, type-checked and normalized expr
+    //    Check in memory cache
+    //    Load with semantic cache >=> put in in-memory cache
+    //Load with semantic  cache
+    //    If hash present and in cache check bytes hash and return as fully resolved and normalized expr
+    //    Else
+    //        load expr from semi-semantic cache
+    //        alpha-normalize expr (why?!)
+    //        check that hash of expr matches expected
+    //        return expr
+    //Load with semi-semantic cache (as code)
+    //    Actually resolve import as text
+    //    Parse expr
+    //    Resolve expr
+    //    Compute semi-semantic hash of resolved expr
+    //    if present in semisemantic cache
+    //        return resolved, type checked normalized expr
+    //    Else
+    //        substitute expr
+    //        typecheck expr with empty context
+    //        beta-normalize expr
+    //        encode and write to semi-semantic cache
+    //        return expr
+    //Load with semi-semantic cache (as text)
+    //    Resolve expr
+    //Load with semi-semantic cache (as code)
+    //    Create location expr
+    //Compute semi-semantic hash
+    //    Take expr with all imports type-checked and normalized
+    //    Encode and hash it
+
     def resolve(i: ImportContext, mode: Expr.ImportMode, hash: Array[Byte]): F[(Expr, Headers)] = {
 
       def resolve(i: ImportContext, hash: Array[Byte]): F[(String, Headers)] = {

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
@@ -57,42 +57,6 @@ private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: 
 
   private def onImport(i: ImportContext, mode: Expr.ImportMode, hash: Array[Byte]): F[Expr] = {
 
-    //TODO replicate Dhall Haskell flow
-    //Compute chain
-    //Referential sanity check
-    //Check cyclic imports
-    //Resolve import - results in fully resolved, type-checked and normalized expr
-    //    Check in memory cache
-    //    Load with semantic cache >=> put in in-memory cache
-    //Load with semantic  cache
-    //    If hash present and in cache check bytes hash and return as fully resolved and normalized expr
-    //    Else
-    //        load expr from semi-semantic cache
-    //        alpha-normalize expr (why?!)
-    //        check that hash of expr matches expected
-    //        write to semantic cache
-    //        return expr
-    //Load with semi-semantic cache (as code)
-    //    Actually resolve import as text
-    //    Parse expr
-    //    Resolve expr
-    //    Compute semi-semantic hash of resolved expr
-    //    if present in semisemantic cache
-    //        return resolved, type checked normalized expr
-    //    Else
-    //        substitute expr
-    //        typecheck expr with empty context
-    //        beta-normalize expr
-    //        encode and write to semi-semantic cache
-    //        return expr
-    //Load with semi-semantic cache (as text)
-    //    Resolve expr
-    //Load with semi-semantic cache (as code)
-    //    Create location expr
-    //Compute semi-semantic hash
-    //    Take expr with all imports type-checked and normalized
-    //    Encode and hash it
-
     //TODO check that equality is sensibly defined for URI and Path
     def rejectCyclicImports(imp: ImportContext, parents: List[ImportContext]): F[Unit] =
       if (parents.contains(imp))

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
@@ -24,7 +24,9 @@ import org.http4s.{EntityDecoder, Request}
 import scala.collection.mutable.{Map => MMap}
 
 //TODO proper error handling
-private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: ImportsCache[F], semiSemanticCache: ImportsCache[F], parents: List[ImportContext])(
+private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: ImportsCache[F],
+                                                                 semiSemanticCache: ImportsCache[F],
+                                                                 parents: List[ImportContext])(
   implicit Client: Client[F],
   F: Sync[F]
 ) extends LiftVisitor[F](F) {
@@ -97,17 +99,16 @@ private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: 
         F.raiseError[Unit](new ResolutionFailure(s"Cyclic import - $imp is already imported in chain $parents"))
       else F.unit
 
-    def importLocation(imp: ImportContext): F[Expr] = {
+    def importLocation(imp: ImportContext): F[Expr] =
       imp match {
         case Local(path) => makeLocation("Local", path.toString)
         // Cannot support this and remain spec-compliant as result type must be <Local Text | Remote Text | Environment Text | Missing>
         case Classpath(path) =>
           F.raiseError(new ResolutionFailure("Importing classpath as location is not supported"))
         case Remote(uri, _) => makeLocation("Remote", uri.toString)
-        case Env(value) => makeLocation("Environment", value)
-        case Missing => F.pure(Expr.makeFieldAccess(Expr.Constants.LOCATION_TYPE, "Missing"))
+        case Env(value)     => makeLocation("Environment", value)
+        case Missing        => F.pure(Expr.makeFieldAccess(Expr.Constants.LOCATION_TYPE, "Missing"))
       }
-    }
 
     def makeLocation(field: String, value: String): F[Expr] =
       F.pure(
@@ -122,21 +123,24 @@ private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: 
 
     def loadWithSemanticCache(imp: ImportContext, mode: ImportMode, hash: Array[Byte]): F[Expr] =
       if (hash == null) loadWithSemiSemanticCache(imp, mode, hash)
-      else for {
-        cached <- semanticCache.get(hash)
-        e <- cached match {
-          case Some(bs) => for {
-            _ <- checkHashesMatch(bs, hash)
-            e <- F.delay(Decode.decode(bs))
-          } yield e
-          case None => for {
-            e <- loadWithSemiSemanticCache(imp, mode, hash)
-            bs = e.alphaNormalize.getEncodedBytes
-            _ <- checkHashesMatch(bs, hash)
-            _ <- semanticCache.put(hash, bs)
-          } yield e
-        }
-      } yield e
+      else
+        for {
+          cached <- semanticCache.get(hash)
+          e <- cached match {
+            case Some(bs) =>
+              for {
+                _ <- checkHashesMatch(bs, hash)
+                e <- F.delay(Decode.decode(bs))
+              } yield e
+            case None =>
+              for {
+                e <- loadWithSemiSemanticCache(imp, mode, hash)
+                bs = e.alphaNormalize.getEncodedBytes
+                _ <- checkHashesMatch(bs, hash)
+                _ <- semanticCache.put(hash, bs)
+              } yield e
+          }
+        } yield e
 
     def fetch(imp: ImportContext): F[String] = imp match {
       case Env(value) =>
@@ -176,47 +180,52 @@ private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: 
     }
 
     def loadWithSemiSemanticCache(imp: ImportContext, mode: ImportMode, hash: Array[Byte]): F[Expr] = mode match {
-      case ImportMode.LOCATION => imp match {
-        case Local(path) => makeLocation("Local", path.toString)
-        // Cannot support this and remain spec-compliant as result type must be <Local Text | Remote Text | Environment Text | Missing>
-        case Classpath(path) =>
-          F.raiseError(new ResolutionFailure("Importing classpath as location is not supported"))
-        case Remote(uri, _) => makeLocation("Remote", uri.toString)
-        case Env(value) => makeLocation("Environment", value)
-        case Missing => F.pure(Expr.makeFieldAccess(Expr.Constants.LOCATION_TYPE, "Missing"))
-      }
-      case ImportMode.RAW_TEXT => for {
-        text <- fetch(imp)
-      } yield Expr.makeTextLiteral(text)
-      case ImportMode.CODE => for {
-        text <- fetch(imp)
-        parsed <- F.delay(DhallParser.parse(text))
-        resolved <- {
-          val v = ResolveImportsVisitor[F](semanticCache, semiSemanticCache, imp :: parents)
-          v.duplicateImportsCache = this.duplicateImportsCache
-          parsed.accept(v)
+      case ImportMode.LOCATION =>
+        imp match {
+          case Local(path) => makeLocation("Local", path.toString)
+          // Cannot support this and remain spec-compliant as result type must be <Local Text | Remote Text | Environment Text | Missing>
+          case Classpath(path) =>
+            F.raiseError(new ResolutionFailure("Importing classpath as location is not supported"))
+          case Remote(uri, _) => makeLocation("Remote", uri.toString)
+          case Env(value)     => makeLocation("Environment", value)
+          case Missing        => F.pure(Expr.makeFieldAccess(Expr.Constants.LOCATION_TYPE, "Missing"))
         }
-        semiHash = MessageDigest.getInstance("SHA-256").digest(resolved.getEncodedBytes)
-        cached <- semiSemanticCache.get(semiHash)
-        expr <- cached match {
-          case Some(bs) => F.delay(Decode.decode(bs))
-          case None => for {
-            _ <- F.delay(typeCheck(resolved))
-            //TODO substitutions here?
-            normalized <- F.delay(resolved.normalize)
-            _ <- semiSemanticCache.put(semiHash, normalized.getEncodedBytes)
-          } yield normalized
-        }
-      } yield expr
+      case ImportMode.RAW_TEXT =>
+        for {
+          text <- fetch(imp)
+        } yield Expr.makeTextLiteral(text)
+      case ImportMode.CODE =>
+        for {
+          text <- fetch(imp)
+          parsed <- F.delay(DhallParser.parse(text))
+          resolved <- {
+            val v = ResolveImportsVisitor[F](semanticCache, semiSemanticCache, imp :: parents)
+            v.duplicateImportsCache = this.duplicateImportsCache
+            parsed.accept(v)
+          }
+          semiHash = MessageDigest.getInstance("SHA-256").digest(resolved.getEncodedBytes)
+          cached <- semiSemanticCache.get(semiHash)
+          expr <- cached match {
+            case Some(bs) => F.delay(Decode.decode(bs))
+            case None =>
+              for {
+                _ <- F.delay(typeCheck(resolved))
+                //TODO substitutions here?
+                normalized <- F.delay(resolved.normalize)
+                _ <- semiSemanticCache.put(semiHash, normalized.getEncodedBytes)
+              } yield normalized
+          }
+        } yield expr
     }
 
     def resolve(imp: ImportContext, mode: ImportMode, hash: Array[Byte]): F[Expr] =
       if (duplicateImportsCache.contains(imp))
         F.delay(duplicateImportsCache.get(imp).get)
-      else for {
-        e <- loadWithSemanticCache(imp, mode, hash)
-        _ <- F.delay(duplicateImportsCache.put(imp, e))
-      } yield e
+      else
+        for {
+          e <- loadWithSemanticCache(imp, mode, hash)
+          _ <- F.delay(duplicateImportsCache.put(imp, e))
+        } yield e
 
     def importNonLocation(imp: ImportContext, mode: ImportMode, hash: Array[Byte]) =
       for {
@@ -234,10 +243,11 @@ private[dhallj] case class ResolveImportsVisitor[F[_] <: AnyRef](semanticCache: 
 
 object ResolveImportsVisitor {
 
-  def mkVisitor[F[_] <: AnyRef : Sync : Client]: F[ResolveImportsVisitor[F]] =
+  def mkVisitor[F[_] <: AnyRef: Sync: Client]: F[ResolveImportsVisitor[F]] =
     (Caching.mkImportsCache[F]("dhall"), Caching.mkImportsCache[F]("dhallj")).mapN((c, c2) => mkVisitor(c, c2))
 
-  def mkVisitor[F[_] <: AnyRef : Sync : Client](semanticCache: ImportsCache[F], semiSemanticCache: ImportsCache[F]): ResolveImportsVisitor[F] =
+  def mkVisitor[F[_] <: AnyRef: Sync: Client](semanticCache: ImportsCache[F],
+                                              semiSemanticCache: ImportsCache[F]): ResolveImportsVisitor[F] =
     ResolveImportsVisitor(semanticCache, semiSemanticCache, Nil)
 
   sealed trait ImportContext

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/ImportResolutionSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/ImportResolutionSuite.scala
@@ -30,7 +30,7 @@ class ImportResolutionSuite(val base: String)
       val cache = initializeCache
       BlazeClientBuilder[IO](global).resource.use { client =>
         implicit val c: Client[IO] = client
-        parsed.accept(ResolveImportsVisitor.mkVisitor(cache))
+        parsed.accept(ResolveImportsVisitor.mkVisitor(cache, NoopImportsCache[IO]))
       }.unsafeRunSync
     }
   }

--- a/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
+++ b/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
@@ -21,13 +21,10 @@ class HashingHTProjectionSuite extends HashingSuite("semantic-hash/success/haske
 class AlphaNormalizationUnitSuite extends AlphaNormalizationSuite("alpha-normalization/success/unit")
 class AlphaNormalizationRegressionSuite extends AlphaNormalizationSuite("alpha-normalization/success/regression")
 
-class TypeCheckingSimpleSuite extends CachingTypeCheckingSuite("type-inference/success/simple")
-class TypeCheckingUnitSuite extends CachingTypeCheckingSuite("type-inference/success/unit")
+class TypeCheckingSimpleSuite extends ParsingTypeCheckingSuite("type-inference/success/simple")
+class TypeCheckingUnitSuite extends ParsingTypeCheckingSuite("type-inference/success/unit")
 class TypeCheckingRegressionSuite extends TypeCheckingSuite("type-inference/success/regression")
 class TypeCheckingOtherSuite extends TypeCheckingSuite("type-inference/success") {
-  //TODO prelude is WAY too slow
-  override def ignored = Set("prelude")
-
   override def slow = Set("prelude")
 }
 class TypeCheckingFailureUnitSuite extends TypeCheckingFailureSuite("type-inference/failure/unit")


### PR DESCRIPTION
- Significant improvements in import resolution performance (we do a _lot_ less type checking now)

- Allows us to enable the type-checking prelude test