### PR TITLE
Import cleanup

### DIFF
--- a/modules/imports/src/main/scala/org/dhallj/imports/CorsComplianceCheck.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/CorsComplianceCheck.scala
@@ -4,7 +4,6 @@ import java.net.URI
 
 import cats.effect.Sync
 import org.dhallj.core.DhallException.ResolutionFailure
-import org.dhallj.imports.ResolveImportsVisitor._
 import org.http4s.Headers
 import org.http4s.headers.`Access-Control-Allow-Origin`
 

--- a/modules/imports/src/main/scala/org/dhallj/imports/ReferentialSanityCheck.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ReferentialSanityCheck.scala
@@ -14,18 +14,18 @@ object ReferentialSanityCheck {
         case ImportContext.Local(path) =>
           F.raiseError(
             new ResolutionFailure(
-              "Referential sanity violation - remote import $uri cannot reference local import $path"
+              s"Referential sanity violation - remote import $uri cannot reference local import $path"
             )
           )
         case ImportContext.Classpath(path) =>
           F.raiseError(
             new ResolutionFailure(
-              "Referential sanity violation - remote import $uri cannot reference classpath import $path"
+              s"Referential sanity violation - remote import $uri cannot reference classpath import $path"
             )
           )
         case ImportContext.Env(v) =>
           F.raiseError(
-            new ResolutionFailure("Referential sanity violation - remote import $uri cannot reference env import $v")
+            new ResolutionFailure(s"Referential sanity violation - remote import $uri cannot reference env import $v")
           )
       }
     case ImportContext.Missing => F.raiseError(new ResolutionFailure(s"Missing import cannot reference import $child"))

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
@@ -144,16 +144,7 @@ final private class ResolveImportsVisitor[F[_] <: AnyRef](
     }
 
     def loadWithSemiSemanticCache(imp: ImportContext, mode: ImportMode, hash: Array[Byte]): F[Expr] = mode match {
-      case ImportMode.LOCATION =>
-        imp match {
-          case ImportContext.Local(path) => makeLocation("Local", path.toString)
-          // Cannot support this and remain spec-compliant as result type must be <Local Text | Remote Text | Environment Text | Missing>
-          case ImportContext.Classpath(path) =>
-            F.raiseError(new ResolutionFailure("Importing classpath as location is not supported"))
-          case ImportContext.Remote(uri, _) => makeLocation("Remote", uri.toString)
-          case ImportContext.Env(value)     => makeLocation("Environment", value)
-          case ImportContext.Missing        => F.pure(Expr.makeFieldAccess(Expr.Constants.LOCATION_TYPE, "Missing"))
-        }
+      case ImportMode.LOCATION => F.raiseError(new ResolutionFailure("Unreachable - location imports already handled"))
       case ImportMode.RAW_TEXT =>
         for {
           text <- fetch(imp)


### PR DESCRIPTION
Departs from the Dhall-Haskell implementation in favour of implementing
the spec correctly as regards as location imports