### PR TITLE
Allow changing the root directory for resolving imports

### DIFF
--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImports.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImports.scala
@@ -1,26 +1,36 @@
 package org.dhallj.imports
 
+import java.nio.file.{Path, Paths}
+
 import cats.effect.Sync
 import org.dhallj.core.Expr
 import org.http4s.client.Client
 
 object Resolver {
   def resolve[F[_] <: AnyRef](expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
-    F.flatMap(ResolveImportsVisitor[F])(expr.accept(_))
+    F.flatMap(ResolveImportsVisitor[F](cwd))(expr.accept(_))
+
+  def resolveRelativeTo[F[_] <: AnyRef](relativeTo: Path)(expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
+    F.flatMap(ResolveImportsVisitor[F](relativeTo))(expr.accept(_))
 
   def resolve[F[_] <: AnyRef](
     semanticCache: ImportCache[F],
     semiSemanticCache: ImportCache[F]
   )(expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
-    expr.accept(ResolveImportsVisitor[F](semanticCache, semiSemanticCache))
+    expr.accept(ResolveImportsVisitor[F](semanticCache, semiSemanticCache, cwd))
 
   def resolve[F[_] <: AnyRef](
     semanticCache: ImportCache[F]
   )(expr: Expr)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
-    expr.accept(ResolveImportsVisitor[F](semanticCache, new ImportCache.NoopImportCache[F]))
+    expr.accept(ResolveImportsVisitor[F](semanticCache, new ImportCache.NoopImportCache[F], cwd))
+
+  private def cwd: Path = Paths.get(".")
 
   final class Ops(val expr: Expr) extends AnyVal {
     def resolveImports[F[_] <: AnyRef](implicit Client: Client[F], F: Sync[F]): F[Expr] =
       resolve[F](expr)
+
+    def resolveImportsRelativeTo[F[_] <: AnyRef](relativeTo: Path)(implicit Client: Client[F], F: Sync[F]): F[Expr] =
+      resolveRelativeTo[F](relativeTo)(expr)
   }
 }

--- a/modules/imports/src/test/scala/org/dhallj/imports/ImportResolutionSuite.scala
+++ b/modules/imports/src/test/scala/org/dhallj/imports/ImportResolutionSuite.scala
@@ -226,7 +226,7 @@ class ImportResolutionSuite extends FunSuite {
     client.use { c =>
       implicit val http: Client[IO] = c
 
-      e.accept(ResolveImportsVisitor[IO](cache))
+      Resolver.resolve(cache)(e)
     }
 
   private case class InMemoryCache() extends ImportCache[IO] {

--- a/tests/src/test/scala/org/dhallj/tests/ImportResolutionSuite.scala
+++ b/tests/src/test/scala/org/dhallj/tests/ImportResolutionSuite.scala
@@ -1,0 +1,36 @@
+package org.dhallj.tests
+
+import java.nio.file.{Path, Paths}
+
+import cats.effect.{ContextShift, IO, Resource}
+import munit.FunSuite
+import org.dhallj.core.Expr
+import org.dhallj.imports.syntax._
+import org.dhallj.parser.DhallParser.parse
+import org.http4s.client._
+import org.http4s.client.blaze._
+
+import scala.concurrent.ExecutionContext.global
+
+class ImportResolutionSuite extends FunSuite {
+
+  implicit val cs: ContextShift[IO] = IO.contextShift(global)
+
+  implicit val client: Resource[IO, Client[IO]] = BlazeClientBuilder[IO](global).resource
+
+  test("Resolve with different base directory") {
+    //Path inside dhall-lang submodule
+    val expr = parse("let x = ./success/prelude/Bool/and/0B.dhall in x")
+    val expected = parse("Bool").normalize
+
+    assert(resolveRelativeTo(Paths.get("./dhall-lang/tests/type-inference"))(expr) == expected)
+  }
+
+  private def resolveRelativeTo(relativeTo: Path)(e: Expr): Expr =
+    client.use { c =>
+      implicit val http: Client[IO] = c
+
+      e.resolveImportsRelativeTo[IO](relativeTo).map(_.normalize)
+    }.unsafeRunSync
+
+}


### PR DESCRIPTION
We can now do
`Resolver.resolve(expr)`
or
`Resolver.resolveRelativeTo(Paths.get("/tmp"))(expr)`