### PR TITLE
J2CL-friendliness

### DIFF
--- a/modules/core/src/main/java/org/dhallj/cbor/MajorType.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/MajorType.java
@@ -35,7 +35,7 @@ public enum MajorType {
       case 7:
         return PRIMITIVE;
       default:
-        throw new IllegalArgumentException(String.format("Invalid CBOR major type %d", b));
+        throw new IllegalArgumentException("Invalid CBOR major type " + Byte.toString(b));
     }
   }
 }

--- a/modules/core/src/main/java/org/dhallj/cbor/NullVisitor.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/NullVisitor.java
@@ -78,6 +78,6 @@ final class NullVisitor<R> implements Visitor<R> {
   }
 
   private R notExpected(String msg) {
-    throw new CborException(String.format("%s not expected - expected null", msg));
+    throw new CborException(msg + " not expected - expected null");
   }
 }

--- a/modules/core/src/main/java/org/dhallj/cbor/Reader.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Reader.java
@@ -230,10 +230,24 @@ public abstract class Reader {
     }
   }
 
+  private static final String unassignedMessage(int v) {
+    StringBuilder builder = new StringBuilder("Primitive ");
+    builder.append(v);
+    builder.append(" is unassigned");
+    return builder.toString();
+  }
+
+  private static final String notValidMessage(int v) {
+    StringBuilder builder = new StringBuilder("Primitive ");
+    builder.append(v);
+    builder.append(" is not valid");
+    return builder.toString();
+  }
+
   private final <R> R readPrimitive(byte b, Visitor<R> visitor) {
     int value = b & 31;
     if (0 <= value && value <= 19) {
-      throw new CborException(String.format("Primitive %d is unassigned", value));
+      throw new CborException(unassignedMessage(value));
     } else if (value == 20) {
       return visitor.onFalse();
     } else if (value == 21) {
@@ -241,7 +255,7 @@ public abstract class Reader {
     } else if (value == 22) {
       return visitor.onNull();
     } else if (value == 23) {
-      throw new CborException(String.format("Primitive %d is unassigned", value));
+      throw new CborException(unassignedMessage(value));
     } else if (value == 24) {
       throw new CborException("Simple value not needed for Dhall");
     } else if (value == 25) {
@@ -283,11 +297,11 @@ public abstract class Reader {
       }
       return visitor.onDoubleFloat(Double.longBitsToDouble(result));
     } else if (28 <= value && value <= 30) {
-      throw new CborException(String.format("Primitive %d is unassigned", value));
+      throw new CborException(unassignedMessage(value));
     } else if (value == 31) {
       throw new CborException("Break stop code not needed for Dhall");
     } else {
-      throw new CborException(String.format("Primitive %d is not valid", value));
+      throw new CborException(notValidMessage(value));
     }
   }
 

--- a/modules/core/src/main/java/org/dhallj/cbor/Reader.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Reader.java
@@ -33,7 +33,7 @@ public abstract class Reader {
       case PRIMITIVE:
         return readPrimitive(b, visitor);
       default:
-        throw new CborException(String.format("Invalid CBOR major type %d", b));
+        throw new CborException("Invalid CBOR major type " + Byte.toString(b));
     }
   }
 
@@ -52,7 +52,7 @@ public abstract class Reader {
     skip55799();
     BigInteger result = readBigNum();
     if (result.compareTo(BigInteger.ZERO) < 0) {
-      throw new CborException(String.format("%s is not a positive big num", result));
+      throw new CborException(result.toString() + " is not a positive big num");
     } else {
       return result;
     }
@@ -78,10 +78,12 @@ public abstract class Reader {
         } else if (tag == 3) {
           return BigInteger.valueOf(-1).subtract(result);
         } else {
-          throw new CborException(String.format("%d is not a valid tag for a bignum", tag));
+          throw new CborException(Long.toString(tag) + " is not a valid tag for a bignum");
         }
       default:
-        throw new CborException(String.format("%d not a valid major type for an Unsigned Integer"));
+        throw new CborException(
+            "Not a valid major type for an Unsigned Integer: "
+                + MajorType.fromByte(next).toString());
     }
   }
 
@@ -161,7 +163,7 @@ public abstract class Reader {
         return entries;
       default:
         throw new CborException(
-            String.format("Cannot read map - major type is %s", MajorType.fromByte(b)));
+            "Cannot read map - major type is " + MajorType.fromByte(b).toString());
     }
   }
 
@@ -213,9 +215,7 @@ public abstract class Reader {
           return visitor.onVariableArray(length, readTextString(next));
         default:
           throw new CborException(
-              String.format(
-                  "Invalid start to CBOR-encoded Dhall expression %s",
-                  MajorType.fromByte(b).toString()));
+              "Invalid start to CBOR-encoded Dhall expression " + MajorType.fromByte(b).toString());
       }
     }
   }
@@ -303,7 +303,7 @@ public abstract class Reader {
             BigInteger tag = readBigInteger(info, read()); // Now advance pointer
             int t = tag.intValue();
             if (t != 55799) {
-              throw new CborException(String.format("Unrecognized CBOR semantic tag %d", t));
+              throw new CborException("Unrecognized CBOR semantic tag " + Integer.toString(t));
             } else {
               skip55799(); // Please tell me no encoders do this
             }

--- a/modules/core/src/main/java/org/dhallj/cbor/Writer.java
+++ b/modules/core/src/main/java/org/dhallj/cbor/Writer.java
@@ -144,7 +144,7 @@ public abstract class Writer {
     } else {
       float asFloat = (float) value;
       if (value == (double) asFloat) {
-        int bits = Float.floatToRawIntBits(asFloat);
+        int bits = Float.floatToIntBits(asFloat);
         this.write(
             (byte) (base | AdditionalInfo.FOUR_BYTES.value),
             (byte) ((bits >> 24) & 0xff),
@@ -153,7 +153,7 @@ public abstract class Writer {
             (byte) ((bits >> 0) & 0xff));
       } else {
 
-        long bits = Double.doubleToRawLongBits(value);
+        long bits = Double.doubleToLongBits(value);
         this.write(
             (byte) (base | AdditionalInfo.EIGHT_BYTES.value),
             (byte) ((bits >> 56) & 0xff),

--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -434,7 +434,20 @@ public abstract class Expr {
           if (quoted) {
             builder.append('\\');
           }
-          builder.append(String.format("\\u%04X", (long) c));
+          String asHex = Long.toHexString((long) c);
+
+          builder.append("\\u");
+
+          if (asHex.length() < 2) {
+            builder.append('0');
+          }
+          if (asHex.length() < 3) {
+            builder.append('0');
+          }
+          if (asHex.length() < 4) {
+            builder.append('0');
+          }
+          builder.append(asHex);
         } else {
           builder.append(c);
         }

--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -868,7 +868,8 @@ public abstract class Expr {
       this.state = state;
       this.size = 0;
       if (sortFields) {
-        this.sortedFields = fields.clone();
+        this.sortedFields = new Entry[fields.length];
+        System.arraycopy(fields, 0, sortedFields, 0, fields.length);
         Arrays.sort(sortedFields, entryComparator);
       } else {
         this.sortedFields = fields;

--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -732,7 +732,7 @@ public abstract class Expr {
 
   public static final Expr makeBuiltIn(String name) {
     if (Constants.getBuiltIn(name) == null) {
-      throw new IllegalArgumentException(String.format("%s is not a built-in", name));
+      throw new IllegalArgumentException(name + " is not a built-in");
     }
     return Constants.getBuiltIn(name);
   }

--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -879,10 +879,6 @@ public abstract class Expr {
     State(Expr expr, int state) {
       this(expr, state, 0);
     }
-
-    public String toString() {
-      return String.format("%s %d %d", this.expr, this.expr.tag, this.state);
-    }
   }
 
   /** Run the given internal visitor on this expression. */

--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -376,7 +376,7 @@ public abstract class Expr {
 
       if (value.tag == Tags.FIELD_ACCESS) {
         Constructors.FieldAccess fieldAccess = (Constructors.FieldAccess) value;
-        return new SimpleImmutableEntry(fieldAccess.base, fieldAccess.fieldName);
+        return new SimpleImmutableEntry<>(fieldAccess.base, fieldAccess.fieldName);
       } else {
         return null;
       }
@@ -546,10 +546,10 @@ public abstract class Expr {
     public static final Expr LOCATION_TYPE =
         makeUnionType(
             new Entry[] {
-              new SimpleImmutableEntry("Local", TEXT),
-              new SimpleImmutableEntry("Remote", TEXT),
-              new SimpleImmutableEntry("Environment", TEXT),
-              new SimpleImmutableEntry("Missing", null)
+              new SimpleImmutableEntry<>("Local", TEXT),
+              new SimpleImmutableEntry<>("Remote", TEXT),
+              new SimpleImmutableEntry<>("Environment", TEXT),
+              new SimpleImmutableEntry<>("Missing", null)
             });
     public static final String MAP_KEY_FIELD_NAME = "mapKey";
     public static final String MAP_VALUE_FIELD_NAME = "mapValue";
@@ -754,8 +754,7 @@ public abstract class Expr {
   }
 
   public static final Expr makeRecordLiteral(String key, Expr value) {
-    return new Constructors.RecordLiteral(
-        new Entry[] {new SimpleImmutableEntry<String, Expr>(key, value)});
+    return new Constructors.RecordLiteral(new Entry[] {new SimpleImmutableEntry<>(key, value)});
   }
 
   public static final Expr makeRecordType(Entry<String, Expr>[] fields) {
@@ -1151,7 +1150,7 @@ public abstract class Expr {
             List<Entry<String, A>> results = new ArrayList<Entry<String, A>>();
             for (int i = current.sortedFields.length - 1; i >= 0; i -= 1) {
               results.add(
-                  new SimpleImmutableEntry(current.sortedFields[i].getKey(), valueStack.poll()));
+                  new SimpleImmutableEntry<>(current.sortedFields[i].getKey(), valueStack.poll()));
             }
             Collections.reverse(results);
             valueStack.push(visitor.onRecord(results));
@@ -1184,7 +1183,7 @@ public abstract class Expr {
             List<Entry<String, A>> results = new ArrayList<Entry<String, A>>();
             for (int i = current.sortedFields.length - 1; i >= 0; i -= 1) {
               results.add(
-                  new SimpleImmutableEntry(current.sortedFields[i].getKey(), valueStack.poll()));
+                  new SimpleImmutableEntry<>(current.sortedFields[i].getKey(), valueStack.poll()));
             }
             Collections.reverse(results);
             valueStack.push(visitor.onRecordType(results));
@@ -1223,7 +1222,7 @@ public abstract class Expr {
             List<Entry<String, A>> results = new ArrayList<Entry<String, A>>();
             for (int i = current.sortedFields.length - 1; i >= 0; i -= 1) {
               results.add(
-                  new SimpleImmutableEntry(current.sortedFields[i].getKey(), valueStack.poll()));
+                  new SimpleImmutableEntry<>(current.sortedFields[i].getKey(), valueStack.poll()));
             }
             Collections.reverse(results);
             valueStack.push(visitor.onUnionType(results));
@@ -1704,8 +1703,7 @@ public abstract class Expr {
         if (fieldsA.length == fieldsB.length) {
           for (int i = 0; i < fieldsA.length; i++) {
             if (!fieldsA[i].getKey().equals(fieldsB[i].getKey())) {
-              return new SimpleImmutableEntry<Expr, Expr>(
-                  fieldsA[i].getValue(), fieldsB[i].getValue());
+              return new SimpleImmutableEntry<>(fieldsA[i].getValue(), fieldsB[i].getValue());
             }
 
             stackA.add(fieldsA[i].getValue());
@@ -1724,8 +1722,7 @@ public abstract class Expr {
         if (fieldsA.length == fieldsB.length) {
           for (int i = 0; i < fieldsA.length; i++) {
             if (!fieldsA[i].getKey().equals(fieldsB[i].getKey())) {
-              return new SimpleImmutableEntry<Expr, Expr>(
-                  fieldsA[i].getValue(), fieldsB[i].getValue());
+              return new SimpleImmutableEntry<>(fieldsA[i].getValue(), fieldsB[i].getValue());
             }
 
             stackA.add(fieldsA[i].getValue());
@@ -1744,15 +1741,14 @@ public abstract class Expr {
         if (fieldsA.length == fieldsB.length) {
           for (int i = 0; i < fieldsA.length; i++) {
             if (!fieldsA[i].getKey().equals(fieldsB[i].getKey())) {
-              return new SimpleImmutableEntry<Expr, Expr>(
-                  fieldsA[i].getValue(), fieldsB[i].getValue());
+              return new SimpleImmutableEntry<>(fieldsA[i].getValue(), fieldsB[i].getValue());
             }
 
             if (fieldsA[i].getValue() != null && fieldsB[i].getValue() != null) {
               stackA.add(fieldsA[i].getValue());
               stackB.add(fieldsB[i].getValue());
             } else if (fieldsA[i].getValue() == null ^ fieldsB[i].getValue() == null) {
-              return new SimpleImmutableEntry<Expr, Expr>(currentA, currentB);
+              return new SimpleImmutableEntry<>(currentA, currentB);
             }
           }
           continue;
@@ -1916,7 +1912,7 @@ public abstract class Expr {
     if (currentA == null && currentB == null) {
       return null;
     } else {
-      return new SimpleImmutableEntry<Expr, Expr>(currentA, currentB);
+      return new SimpleImmutableEntry<>(currentA, currentB);
     }
   }
 

--- a/modules/core/src/main/java/org/dhallj/core/Operator.java
+++ b/modules/core/src/main/java/org/dhallj/core/Operator.java
@@ -83,8 +83,7 @@ public enum Operator {
     } else if (input.equals(COMPLETE.value)) {
       return COMPLETE;
     } else {
-      throw new IllegalArgumentException(
-          String.format("No org.dhallj.core.Operator represented by %s", input));
+      throw new IllegalArgumentException("No org.dhallj.core.Operator represented by " + input);
     }
   }
 }

--- a/modules/core/src/main/java/org/dhallj/core/binary/CborDecodingVisitor.java
+++ b/modules/core/src/main/java/org/dhallj/core/binary/CborDecodingVisitor.java
@@ -110,7 +110,7 @@ final class CborDecodingVisitor implements Visitor<Expr> {
       case Label.EMPTY_LIST_WITH_ABSTRACT_TYPE:
         return readEmptyListAbstractType(length);
       default:
-        throw new DecodingException(String.format("Array tag %d undefined", tag));
+        throw new DecodingException("Array tag " + Integer.toString(tag) + " undefined");
     }
   }
 
@@ -219,7 +219,8 @@ final class CborDecodingVisitor implements Visitor<Expr> {
     if (operator != null) {
       return Expr.makeOperatorApplication(operator, lhs, rhs);
     } else {
-      throw new DecodingException(String.format("Operator tag %d is undefined", operatorLabel));
+      throw new DecodingException(
+          "Operator tag " + Integer.toString(operatorLabel) + " is undefined");
     }
   }
 
@@ -253,7 +254,7 @@ final class CborDecodingVisitor implements Visitor<Expr> {
         return Expr.makeEmptyListLiteral(tpe);
       }
     } else {
-      throw new DecodingException(String.format("List of abstract type %s must be empty"));
+      throw new DecodingException("List of abstract type must be empty");
     }
   }
 
@@ -440,7 +441,7 @@ final class CborDecodingVisitor implements Visitor<Expr> {
       case Label.IMPORT_TYPE_CLASSPATH:
         return readClasspathImport(length, mode, hash, "/");
       default:
-        throw new DecodingException(String.format("Import type %d is undefined", tag));
+        throw new DecodingException("Import type " + Integer.toString(tag) + " is undefined");
     }
   }
 
@@ -453,7 +454,7 @@ final class CborDecodingVisitor implements Visitor<Expr> {
     } else if (m == 2) {
       return Expr.ImportMode.LOCATION;
     } else {
-      throw new DecodingException(String.format("Import mode %d is undefined", m));
+      throw new DecodingException("Import mode " + Integer.toString(m) + " is undefined");
     }
   }
 

--- a/modules/core/src/main/java/org/dhallj/core/normalization/BetaNormalizeApplication.java
+++ b/modules/core/src/main/java/org/dhallj/core/normalization/BetaNormalizeApplication.java
@@ -85,11 +85,11 @@ final class BetaNormalizeApplication {
     return Expr.makeApplication(base, args);
   }
 
+  private static final Entry<String, Expr> indexField =
+      new SimpleImmutableEntry<>("index", Expr.Constants.NATURAL);
+
   private static final Expr indexedRecordType(Expr type) {
-    Entry[] fields = {
-      new SimpleImmutableEntry("index", Expr.Constants.NATURAL),
-      new SimpleImmutableEntry("value", type)
-    };
+    Entry[] fields = {indexField, new SimpleImmutableEntry<>("value", type)};
     return Expr.makeRecordType(fields);
   }
 
@@ -302,8 +302,9 @@ final class BetaNormalizeApplication {
         for (Expr value : argAsListLiteral) {
           List<Entry<String, Expr>> fields = new ArrayList<>();
           fields.add(
-              new SimpleImmutableEntry("index", Expr.makeNaturalLiteral(BigInteger.valueOf(i++))));
-          fields.add(new SimpleImmutableEntry("value", value));
+              new SimpleImmutableEntry<>(
+                  "index", Expr.makeNaturalLiteral(BigInteger.valueOf(i++))));
+          fields.add(new SimpleImmutableEntry<>("value", value));
           result.add(Expr.makeRecordLiteral(fields));
         }
 

--- a/modules/core/src/main/java/org/dhallj/core/normalization/BetaNormalizeProjection.java
+++ b/modules/core/src/main/java/org/dhallj/core/normalization/BetaNormalizeProjection.java
@@ -31,7 +31,8 @@ final class BetaNormalizeProjection extends ExternalVisitor.Constant<Expr> {
       return result;
     } else {
       // We have to sort the field names if we can't reduce.
-      String[] newFieldNames = fieldNames.clone();
+      String[] newFieldNames = new String[fieldNames.length];
+      System.arraycopy(fieldNames, 0, newFieldNames, 0, fieldNames.length);
       Arrays.sort(newFieldNames);
       return Expr.makeProjection(base, newFieldNames);
     }

--- a/modules/core/src/main/java/org/dhallj/core/typechecking/BuiltInTypes.java
+++ b/modules/core/src/main/java/org/dhallj/core/typechecking/BuiltInTypes.java
@@ -93,7 +93,8 @@ final class BuiltInTypes {
     mappings.put("List/last", listAToOptionalA);
 
     Entry[] indexedRecordFields = {
-      new SimpleImmutableEntry("index", Constants.NATURAL), new SimpleImmutableEntry("value", _a)
+      new SimpleImmutableEntry<>("index", Constants.NATURAL),
+      new SimpleImmutableEntry<>("value", _a)
     };
 
     mappings.put(

--- a/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheck.java
+++ b/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheck.java
@@ -312,7 +312,7 @@ public final class TypeCheck implements ExternalVisitor<Expr> {
           }
           missing.add(fieldName);
         } else {
-          newFields.add(new SimpleImmutableEntry(fieldName, value));
+          newFields.add(new SimpleImmutableEntry<>(fieldName, value));
         }
       }
 
@@ -621,8 +621,8 @@ public final class TypeCheck implements ExternalVisitor<Expr> {
       // The input record is non-empty.
       if (firstType != null) {
         Entry[] inferredTypeFields = {
-          new SimpleImmutableEntry(Constants.MAP_KEY_FIELD_NAME, Constants.TEXT),
-          new SimpleImmutableEntry(Constants.MAP_VALUE_FIELD_NAME, firstType)
+          new SimpleImmutableEntry<>(Constants.MAP_KEY_FIELD_NAME, Constants.TEXT),
+          new SimpleImmutableEntry<>(Constants.MAP_VALUE_FIELD_NAME, firstType)
         };
 
         Expr inferredType =
@@ -763,8 +763,8 @@ public final class TypeCheck implements ExternalVisitor<Expr> {
 
   private static final List<Entry<String, Expr>> makeOptionalConstructors(Expr type) {
     List<Entry<String, Expr>> constructors = new ArrayList<>();
-    constructors.add(new SimpleImmutableEntry("None", null));
-    constructors.add(new SimpleImmutableEntry("Some", type));
+    constructors.add((Entry<String, Expr>) new SimpleImmutableEntry<>("None", (Expr) null));
+    constructors.add((Entry<String, Expr>) new SimpleImmutableEntry<>("Some", type));
     return constructors;
   }
 

--- a/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheckFailure.java
+++ b/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheckFailure.java
@@ -20,7 +20,7 @@ public final class TypeCheckFailure extends DhallException {
   }
 
   static TypeCheckFailure makeUnboundVariableError(String name) {
-    return new TypeCheckFailure(String.format("Unbound variable: %s", name));
+    return new TypeCheckFailure("Unbound variable: " + name);
   }
 
   static TypeCheckFailure makeOperatorError(Operator operator) {
@@ -29,24 +29,24 @@ public final class TypeCheckFailure extends DhallException {
       case AND:
       case EQUALS:
       case NOT_EQUALS:
-        return new TypeCheckFailure(String.format("%s only works on Bools", operator));
+        return new TypeCheckFailure(operator.toString() + " only works on Bools");
       case PLUS:
       case TIMES:
-        return new TypeCheckFailure(String.format("%s only works on Naturals", operator));
+        return new TypeCheckFailure(operator.toString() + " only works on Naturals");
       case TEXT_APPEND:
-        return new TypeCheckFailure(String.format("%s only works on Text", operator));
+        return new TypeCheckFailure(operator.toString() + " only works on Text");
       case LIST_APPEND:
-        return new TypeCheckFailure(String.format("%s only works on Lists", operator));
+        return new TypeCheckFailure(operator.toString() + " only works on Lists");
       case COMBINE:
       case PREFER:
         return new TypeCheckFailure("You can only combine records");
       case COMBINE_TYPES:
         return new TypeCheckFailure(
-            String.format("%s requires arguments that are record types", operator));
+            operator.toString() + " requires arguments that are record types");
       case EQUIVALENT:
         return new TypeCheckFailure("Incomparable expression");
       default:
-        return new TypeCheckFailure(String.format("Operator error on %s", operator));
+        return new TypeCheckFailure("Operator error on " + operator.toString());
     }
   }
 
@@ -67,7 +67,7 @@ public final class TypeCheckFailure extends DhallException {
   }
 
   static TypeCheckFailure makeBuiltInApplicationError(String name, Expr arg, Expr argType) {
-    return new TypeCheckFailure(String.format("Can't apply %s", name));
+    return new TypeCheckFailure("Can't apply " + name);
   }
 
   static TypeCheckFailure makeApplicationTypeError(Expr expected, Expr received) {
@@ -107,11 +107,11 @@ public final class TypeCheckFailure extends DhallException {
   }
 
   static TypeCheckFailure makeFieldAccessRecordMissingError(String fieldName) {
-    return new TypeCheckFailure(String.format("Missing record field: %s", fieldName));
+    return new TypeCheckFailure("Missing record field: " + fieldName);
   }
 
   static TypeCheckFailure makeFieldAccessUnionMissingError(String fieldName) {
-    return new TypeCheckFailure(String.format("Missing constructor: %s", fieldName));
+    return new TypeCheckFailure("Missing constructor: " + fieldName);
   }
 
   static TypeCheckFailure makeProjectionError() {
@@ -123,7 +123,7 @@ public final class TypeCheckFailure extends DhallException {
   }
 
   static TypeCheckFailure makeFieldDuplicateError(String fieldName) {
-    return new TypeCheckFailure(String.format("duplicate field: %s", fieldName));
+    return new TypeCheckFailure("duplicate field: " + fieldName);
   }
 
   static TypeCheckFailure makeListTypeMismatchError(Expr type1, Expr type2) {
@@ -148,7 +148,7 @@ public final class TypeCheckFailure extends DhallException {
 
   /** Not sure under what conditions this wouldn't be caught by the parser.s */
   static TypeCheckFailure makeAlternativeDuplicateError(String fieldName) {
-    return new TypeCheckFailure(String.format("duplicate field: %s", fieldName));
+    return new TypeCheckFailure("duplicate field: " + fieldName);
   }
 
   static TypeCheckFailure makeMergeHandlersTypeError(Expr type) {
@@ -160,11 +160,11 @@ public final class TypeCheckFailure extends DhallException {
   }
 
   static TypeCheckFailure makeMergeHandlerMissingError(String fieldName) {
-    return new TypeCheckFailure(String.format("Missing handler: %s", fieldName));
+    return new TypeCheckFailure("Missing handler: " + fieldName);
   }
 
   static TypeCheckFailure makeMergeHandlerUnusedError(String fieldName) {
-    return new TypeCheckFailure(String.format("Unused handler: %s", fieldName));
+    return new TypeCheckFailure("Unused handler: " + fieldName);
   }
 
   static TypeCheckFailure makeMergeHandlerTypeInvalidError(Expr expected, Expr type) {
@@ -173,7 +173,7 @@ public final class TypeCheckFailure extends DhallException {
 
   static TypeCheckFailure makeMergeHandlerTypeNotFunctionError(
       String fieldName, Expr expected, Expr type) {
-    return new TypeCheckFailure(String.format("Handler for %s is not a function", fieldName));
+    return new TypeCheckFailure("Handler for " + fieldName + " is not a function");
   }
 
   static TypeCheckFailure makeMergeHandlerTypeMismatchError(Expr type1, Expr type2) {

--- a/modules/parser/src/main/java/org/dhallj/parser/support/Comment.java
+++ b/modules/parser/src/main/java/org/dhallj/parser/support/Comment.java
@@ -34,10 +34,4 @@ final class Comment {
   public final int getEndColumn() {
     return this.endColumn;
   }
-
-  public String toString() {
-    return String.format(
-        "%s [%d, %d, %d, %d]",
-        content, getBeginLine(), getBeginColumn(), getEndLine(), getEndColumn());
-  }
 }

--- a/modules/parser/src/main/java/org/dhallj/parser/support/ParsingHelpers.java
+++ b/modules/parser/src/main/java/org/dhallj/parser/support/ParsingHelpers.java
@@ -538,7 +538,7 @@ final class ParsingHelpers {
       }
 
       if (parts.isEmpty()) {
-        dedotted.add(new SimpleImmutableEntry(firstPart, value));
+        dedotted.add(new SimpleImmutableEntry<>(firstPart, value));
       } else {
         Collections.reverse(parts);
         Expr current = value;
@@ -546,7 +546,7 @@ final class ParsingHelpers {
         for (String part : parts) {
           current = Expr.makeRecordLiteral(part, current);
         }
-        dedotted.add(new SimpleImmutableEntry(firstPart, current));
+        dedotted.add(new SimpleImmutableEntry<>(firstPart, current));
       }
     }
 
@@ -568,7 +568,7 @@ final class ParsingHelpers {
           }
         }
 
-        desugared.add(new SimpleImmutableEntry(key, current));
+        desugared.add(new SimpleImmutableEntry<>(key, current));
 
         seen.add(key);
       }

--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -816,7 +816,7 @@ Expr.Parsed EMPTY_LIST_LITERAL(): {
   Expr.Parsed type;
   Token first;
   Token t0;
-  StringBuilder builder = new StringBuilder('[');
+  StringBuilder builder = new StringBuilder("[");
 } {
   (
     first=<BRACKET_OPEN>


### PR DESCRIPTION
This PR includes most of the code changes needed for #58 (the `converters` package needs some more substantial changes).

I still find doing without `String.format` kind of annoying, but it seems less bad to me on this pass, and I think it's worth it to get J2CL support. In some cases I think simple string concatenation is actually even a little nicer.

I also went ahead and changed a bunch of places where we were using raw types in Java to use inferred types, even though J2CL only had a problem with a couple of them.