### PR TITLE
Set up J2CL JavaScript build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ tmp/
 .bloop/
 .metals/
 project/metals.sbt
+bazel-bin
+bazel-dhallj
+bazel-out
+bazel-testlogs

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,18 @@
+workspace(name = "org_dhallj")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Load j2cl repository
+http_archive(
+    name = "com_google_j2cl",
+    strip_prefix = "j2cl-master",
+    url = "https://github.com/google/j2cl/archive/master.zip",
+)
+
+load("@com_google_j2cl//build_defs:repository.bzl", "load_j2cl_repo_deps")
+
+load_j2cl_repo_deps()
+
+load("@com_google_j2cl//build_defs:rules.bzl", "setup_j2cl_workspace")
+
+setup_j2cl_workspace()

--- a/javascript/BUILD
+++ b/javascript/BUILD
@@ -1,0 +1,9 @@
+load("@com_google_j2cl//build_defs:rules.bzl", "j2cl_application")
+
+j2cl_application(
+    name = "dhall",
+    closure_defines = {"jre.classMetadata": "'STRIPPED'"},
+    entry_points = ["dhall.js"],
+    jre_checks_check_level = "MINIMAL",
+    deps = ["//javascript/api:dhall_js"],
+)

--- a/javascript/api/BUILD
+++ b/javascript/api/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+load("@com_google_j2cl//build_defs:rules.bzl", "j2cl_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+j2cl_library(
+    name = "dhall_js_java",
+    srcs = ["DhallJs.java"],
+    deps = [
+        "//modules/core",
+        "//modules/parser",
+    ],
+)
+
+closure_js_library(
+    name = "dhall_js",
+    srcs = ["dhall.js"],
+    deps = [":dhall_js_java"],
+)

--- a/javascript/api/DhallJs.java
+++ b/javascript/api/DhallJs.java
@@ -1,0 +1,20 @@
+package org.dhallj.js;
+
+import org.dhallj.core.Expr;
+import org.dhallj.parser.DhallParser;
+import jsinterop.annotations.JsType;
+
+@JsType
+public class DhallJs {
+  public static String parse(String input) {
+    return DhallParser.parse(input).toString();
+  }
+
+  public static String normalize(String input) {
+    return DhallParser.parse(input).normalize().toString();
+  }
+
+  public static String typeCheck(String input) {
+    return Expr.Util.typeCheck(DhallParser.parse(input)).toString();
+  }
+}

--- a/javascript/api/dhall.js
+++ b/javascript/api/dhall.js
@@ -1,0 +1,36 @@
+goog.module('dhall.js');
+
+var DhallJs = goog.require('org.dhallj.js.DhallJs');
+
+/**
+ * @param {string} input
+ * @return {null|string}
+ */
+function parse(input) {
+  return DhallJs.parse(input);
+}
+
+/**
+ * @param {string} input
+ * @return {null|string}
+ */
+function typeCheck(input) {
+  return DhallJs.typeCheck(input);
+}
+
+/**
+ * @param {string} input
+ * @return {null|string}
+ */
+function normalize(input) {
+  return DhallJs.normalize(input);
+}
+
+// Otherwise we seem to lose stuff with some configurations?
+parse("1");
+typeCheck("1");
+normalize("1");
+
+goog.exportSymbol("parse", parse);
+goog.exportSymbol("typeCheck", typeCheck);
+goog.exportSymbol("normalize", normalize);

--- a/javascript/jre/BUILD
+++ b/javascript/jre/BUILD
@@ -1,0 +1,30 @@
+load("@com_google_j2cl//build_defs:rules.bzl", "j2cl_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+j2cl_library(
+    name = "java_io",
+    srcs = [
+        "BufferedReader.java",
+        "InputStreamReader.java",
+    ],
+)
+
+j2cl_library(
+    name = "java_net",
+    srcs = [
+        "URI.java",
+        "URISyntaxException.java",
+    ],
+)
+
+j2cl_library(
+    name = "java_nio_file",
+    srcs = [
+        "InvalidPathException.java",
+        "Path.java",
+        "Paths.java",
+    ],
+)

--- a/javascript/jre/BufferedReader.java
+++ b/javascript/jre/BufferedReader.java
@@ -1,0 +1,11 @@
+package java.io;
+
+public class BufferedReader extends Reader {
+  public BufferedReader(InputStreamReader stream) {}
+
+  public int read(char[] cbuf, int off, int len) {
+    return -1;
+  }
+
+  public void close() {}
+}

--- a/javascript/jre/InputStreamReader.java
+++ b/javascript/jre/InputStreamReader.java
@@ -1,0 +1,11 @@
+package java.io;
+
+public class InputStreamReader extends Reader {
+  public InputStreamReader(InputStream in) {}
+  public InputStreamReader(InputStream in, String charsetName) {}
+  public int read(char[] cbuf, int off, int len) {
+    return -1;
+  }
+
+  public void close() {}
+}

--- a/javascript/jre/InvalidPathException.java
+++ b/javascript/jre/InvalidPathException.java
@@ -1,0 +1,3 @@
+package java.nio.file;
+
+public class InvalidPathException extends IllegalArgumentException {}

--- a/javascript/jre/Path.java
+++ b/javascript/jre/Path.java
@@ -1,0 +1,27 @@
+package java.nio.file;
+
+import java.util.Iterator;
+
+public class Path {
+  private final String input;
+
+  public Path(String input) {
+    this.input = input;
+  }
+
+  public final boolean isAbsolute() {
+    return this.input.charAt(0) == '/';
+  }
+
+  public final Iterator<Path> iterator() {
+    return null;
+  }
+
+  public final int getNameCount() {
+    return 0;
+  }
+
+  public Path resolve(String other) {
+    return this;
+  }
+}

--- a/javascript/jre/Paths.java
+++ b/javascript/jre/Paths.java
@@ -1,0 +1,11 @@
+package java.nio.file;
+
+public class Paths {
+  /**
+   * @throws  InvalidPathException
+   *          if the path string cannot be converted to a {@code Path}
+   */
+  public static final Path get(String input) {
+    return new Path(input);
+  }
+}

--- a/javascript/jre/URI.java
+++ b/javascript/jre/URI.java
@@ -1,0 +1,25 @@
+package java.net;
+
+public class URI {
+  private final String input;
+
+  public URI(String input) throws URISyntaxException {
+    this.input = input;
+  }
+
+  public final String getScheme() {
+    return "";
+  }
+
+  public final String getAuthority() {
+    return "";
+  }
+
+  public final String getPath() {
+    return "";
+  }
+
+  public final String getQuery() {
+    return "";
+  }
+}

--- a/javascript/jre/URISyntaxException.java
+++ b/javascript/jre/URISyntaxException.java
@@ -1,0 +1,3 @@
+package java.net;
+
+public class URISyntaxException extends Throwable {}

--- a/modules/core/BUILD
+++ b/modules/core/BUILD
@@ -1,0 +1,27 @@
+load("@com_google_j2cl//build_defs:rules.bzl", "j2cl_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+j2cl_library(
+    name = "cbor",
+    srcs = glob([
+        "src/main/java/org/dhallj/cbor/*.java",
+    ]),
+)
+
+j2cl_library(
+    name = "core",
+    srcs = glob([
+        "src/main/java/org/dhallj/core/*.java",
+        "src/main/java/org/dhallj/core/binary/*.java",
+        "src/main/java/org/dhallj/core/normalization/*.java",
+        "src/main/java/org/dhallj/core/typechecking/*.java",
+    ]),
+    deps = [
+        ":cbor",
+        "//javascript/jre:java_net",
+        "//javascript/jre:java_nio_file",
+    ],
+)

--- a/modules/parser/BUILD
+++ b/modules/parser/BUILD
@@ -1,0 +1,20 @@
+load("@com_google_j2cl//build_defs:rules.bzl", "j2cl_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+j2cl_library(
+    name = "parser",
+    srcs = glob([
+        "src/main/java/org/dhallj/parser/*.java",
+        "src/main/java/org/dhallj/parser/support/*.java",
+        "target/javacc/*.java",
+    ]),
+    deps = [
+        "//javascript/jre:java_io",
+        "//javascript/jre:java_net",
+        "//javascript/jre:java_nio_file",
+        "//modules/core",
+    ],
+)


### PR DESCRIPTION
Together with #63 this is my experiment from a couple of days ago described in #58.

If you run `bazel build javascript:dhall` (and have a recent-ish version of bazel on your machine), you'll get a JavaScript file in `bazel-bin/javascript/dhall.js` that you can use as described in #58.

If we merge this I'll close #58 and we can open new issues for things like refining the JavaScript API and setting up packaging or publishing or whatever.

At some point we might want to run the bazel build in CI, but right now I don't think it's worth the effort. There's a chance we'll accidentally introduce incompatible changes, but they should be easy to identify and fix.