### PR TITLE
Remove csrng.net dependency

### DIFF
--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -520,13 +520,12 @@ public abstract class Expr {
     LOCATION;
 
     public String toString() {
-      switch (this) {
-        case RAW_TEXT:
-          return "Text";
-        case LOCATION:
-          return "Location";
-        default:
-          return "Code";
+      if (this == RAW_TEXT) {
+        return "Text";
+      } else if (this == LOCATION) {
+        return "Location";
+      } else {
+        return "Code";
       }
     }
   }

--- a/modules/core/src/main/java/org/dhallj/core/ToStringVisitor.java
+++ b/modules/core/src/main/java/org/dhallj/core/ToStringVisitor.java
@@ -98,6 +98,10 @@ final class ToStringVisitor extends Visitor.NoPrepareEvents<ToStringState> {
   }
 
   private static boolean isSimpleLabel(String name) {
+    if (name.length() == 0) {
+      return false;
+    }
+
     char c = name.charAt(0);
     if (!isAlpha(c) && c != '_') {
       return false;

--- a/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheckFailure.java
+++ b/modules/core/src/main/java/org/dhallj/core/typechecking/TypeCheckFailure.java
@@ -15,200 +15,200 @@ public final class TypeCheckFailure extends DhallException {
     super(message);
   }
 
-  static TypeCheckFailure makeSortError() {
+  static final TypeCheckFailure makeSortError() {
     return new TypeCheckFailure("Sort has no type, kind, or sort");
   }
 
-  static TypeCheckFailure makeUnboundVariableError(String name) {
+  static final TypeCheckFailure makeUnboundVariableError(String name) {
     return new TypeCheckFailure("Unbound variable: " + name);
   }
 
-  static TypeCheckFailure makeOperatorError(Operator operator) {
-    switch (operator) {
-      case OR:
-      case AND:
-      case EQUALS:
-      case NOT_EQUALS:
-        return new TypeCheckFailure(operator.toString() + " only works on Bools");
-      case PLUS:
-      case TIMES:
-        return new TypeCheckFailure(operator.toString() + " only works on Naturals");
-      case TEXT_APPEND:
-        return new TypeCheckFailure(operator.toString() + " only works on Text");
-      case LIST_APPEND:
-        return new TypeCheckFailure(operator.toString() + " only works on Lists");
-      case COMBINE:
-      case PREFER:
-        return new TypeCheckFailure("You can only combine records");
-      case COMBINE_TYPES:
-        return new TypeCheckFailure(
-            operator.toString() + " requires arguments that are record types");
-      case EQUIVALENT:
-        return new TypeCheckFailure("Incomparable expression");
-      default:
-        return new TypeCheckFailure("Operator error on " + operator.toString());
+  static final TypeCheckFailure makeOperatorError(Operator operator) {
+    String message;
+
+    if (operator == Operator.OR
+        || operator == Operator.AND
+        || operator == Operator.EQUALS
+        || operator == Operator.NOT_EQUALS) {
+      message = operator.toString() + " only works on Bools";
+    } else if (operator == Operator.PLUS || operator == Operator.TIMES) {
+      message = operator.toString() + " only works on Naturals";
+    } else if (operator == Operator.TEXT_APPEND) {
+      message = operator.toString() + " only works on Text";
+    } else if (operator == Operator.LIST_APPEND) {
+      message = operator.toString() + " only works on Lists";
+    } else if (operator == Operator.COMBINE || operator == Operator.PREFER) {
+      message = "You can only combine records";
+    } else if (operator == Operator.COMBINE_TYPES) {
+      message = operator.toString() + " requires arguments that are record types";
+    } else if (operator == Operator.EQUIVALENT) {
+      message = "Incomparable expression";
+    } else {
+      message = "Operator error on " + operator.toString();
     }
+
+    return new TypeCheckFailure(message);
   }
 
-  static TypeCheckFailure makeListAppendError(Expr lhs, Expr rhs) {
+  static final TypeCheckFailure makeListAppendError(Expr lhs, Expr rhs) {
     return new TypeCheckFailure("You can only append Lists with matching element types");
   }
 
-  static TypeCheckFailure makeEquivalenceError(Expr lhs, Expr rhs) {
+  static final TypeCheckFailure makeEquivalenceError(Expr lhs, Expr rhs) {
     return new TypeCheckFailure("You can only append Lists with matching element types");
   }
 
-  static TypeCheckFailure makeInterpolationError(Expr interpolated, Expr interpolatedType) {
+  static final TypeCheckFailure makeInterpolationError(Expr interpolated, Expr interpolatedType) {
     return new TypeCheckFailure("You can only interpolate Text");
   }
 
-  static TypeCheckFailure makeSomeApplicationError(Expr arg, Expr argType) {
+  static final TypeCheckFailure makeSomeApplicationError(Expr arg, Expr argType) {
     return new TypeCheckFailure("Some argument has the wrong type");
   }
 
-  static TypeCheckFailure makeBuiltInApplicationError(String name, Expr arg, Expr argType) {
+  static final TypeCheckFailure makeBuiltInApplicationError(String name, Expr arg, Expr argType) {
     return new TypeCheckFailure("Can't apply " + name);
   }
 
-  static TypeCheckFailure makeApplicationTypeError(Expr expected, Expr received) {
+  static final TypeCheckFailure makeApplicationTypeError(Expr expected, Expr received) {
     return new TypeCheckFailure("Wrong type of function argument");
   }
 
-  static TypeCheckFailure makeApplicationError(Expr base, Expr arg) {
+  static final TypeCheckFailure makeApplicationError(Expr base, Expr arg) {
     return new TypeCheckFailure("Not a function");
   }
 
-  static TypeCheckFailure makeUnresolvedImportError() {
+  static final TypeCheckFailure makeUnresolvedImportError() {
     return new TypeCheckFailure("Can't type-check unresolved import");
   }
 
-  static TypeCheckFailure makeIfPredicateError(Expr type) {
+  static final TypeCheckFailure makeIfPredicateError(Expr type) {
     return new TypeCheckFailure("Invalid predicate for if");
   }
 
-  static TypeCheckFailure makeIfBranchTypeMismatchError(Expr thenType, Expr elseType) {
+  static final TypeCheckFailure makeIfBranchTypeMismatchError(Expr thenType, Expr elseType) {
     return new TypeCheckFailure("if branches must have matching types");
   }
 
-  static TypeCheckFailure makeIfBranchError(Expr type) {
+  static final TypeCheckFailure makeIfBranchError(Expr type) {
     return new TypeCheckFailure("if branch is not a term");
   }
 
-  static TypeCheckFailure makeLambdaInputError(Expr type) {
+  static final TypeCheckFailure makeLambdaInputError(Expr type) {
     return new TypeCheckFailure("Invalid function input");
   }
 
-  static TypeCheckFailure makeAssertError(Expr type) {
+  static final TypeCheckFailure makeAssertError(Expr type) {
     return new TypeCheckFailure("Not an equivalence");
   }
 
-  static TypeCheckFailure makeFieldAccessError() {
+  static final TypeCheckFailure makeFieldAccessError() {
     return new TypeCheckFailure("Not a record or union");
   }
 
-  static TypeCheckFailure makeFieldAccessRecordMissingError(String fieldName) {
+  static final TypeCheckFailure makeFieldAccessRecordMissingError(String fieldName) {
     return new TypeCheckFailure("Missing record field: " + fieldName);
   }
 
-  static TypeCheckFailure makeFieldAccessUnionMissingError(String fieldName) {
+  static final TypeCheckFailure makeFieldAccessUnionMissingError(String fieldName) {
     return new TypeCheckFailure("Missing constructor: " + fieldName);
   }
 
-  static TypeCheckFailure makeProjectionError() {
+  static final TypeCheckFailure makeProjectionError() {
     return new TypeCheckFailure("Not a record");
   }
 
-  static TypeCheckFailure makeFieldTypeError(String fieldName) {
+  static final TypeCheckFailure makeFieldTypeError(String fieldName) {
     return new TypeCheckFailure("Invalid field type");
   }
 
-  static TypeCheckFailure makeFieldDuplicateError(String fieldName) {
+  static final TypeCheckFailure makeFieldDuplicateError(String fieldName) {
     return new TypeCheckFailure("duplicate field: " + fieldName);
   }
 
-  static TypeCheckFailure makeListTypeMismatchError(Expr type1, Expr type2) {
+  static final TypeCheckFailure makeListTypeMismatchError(Expr type1, Expr type2) {
     return new TypeCheckFailure("List elements should all have the same type");
   }
 
-  static TypeCheckFailure makeListTypeError(Expr type) {
+  static final TypeCheckFailure makeListTypeError(Expr type) {
     return new TypeCheckFailure("Invalid type for List");
   }
 
-  static TypeCheckFailure makeAnnotationError(Expr expected, Expr received) {
+  static final TypeCheckFailure makeAnnotationError(Expr expected, Expr received) {
     return new TypeCheckFailure("Expression doesn't match annotation");
   }
 
-  static TypeCheckFailure makeAlternativeTypeMismatchError(Expr type) {
+  static final TypeCheckFailure makeAlternativeTypeMismatchError(Expr type) {
     return new TypeCheckFailure("Alternative annotation mismatch");
   }
 
-  static TypeCheckFailure makeAlternativeTypeError(Expr type) {
+  static final TypeCheckFailure makeAlternativeTypeError(Expr type) {
     return new TypeCheckFailure("Invalid alternative type");
   }
 
-  /** Not sure under what conditions this wouldn't be caught by the parser.s */
-  static TypeCheckFailure makeAlternativeDuplicateError(String fieldName) {
+  /** Not sure under what conditions this wouldn't be caught by the parser. */
+  static final TypeCheckFailure makeAlternativeDuplicateError(String fieldName) {
     return new TypeCheckFailure("duplicate field: " + fieldName);
   }
 
-  static TypeCheckFailure makeMergeHandlersTypeError(Expr type) {
+  static final TypeCheckFailure makeMergeHandlersTypeError(Expr type) {
     return new TypeCheckFailure("merge expects a record of handlers");
   }
 
-  static TypeCheckFailure makeMergeUnionTypeError(Expr type) {
+  static final TypeCheckFailure makeMergeUnionTypeError(Expr type) {
     return new TypeCheckFailure("toMap expects a union or an Optional");
   }
 
-  static TypeCheckFailure makeMergeHandlerMissingError(String fieldName) {
+  static final TypeCheckFailure makeMergeHandlerMissingError(String fieldName) {
     return new TypeCheckFailure("Missing handler: " + fieldName);
   }
 
-  static TypeCheckFailure makeMergeHandlerUnusedError(String fieldName) {
+  static final TypeCheckFailure makeMergeHandlerUnusedError(String fieldName) {
     return new TypeCheckFailure("Unused handler: " + fieldName);
   }
 
-  static TypeCheckFailure makeMergeHandlerTypeInvalidError(Expr expected, Expr type) {
+  static final TypeCheckFailure makeMergeHandlerTypeInvalidError(Expr expected, Expr type) {
     return new TypeCheckFailure("Wrong handler input type");
   }
 
-  static TypeCheckFailure makeMergeHandlerTypeNotFunctionError(
+  static final TypeCheckFailure makeMergeHandlerTypeNotFunctionError(
       String fieldName, Expr expected, Expr type) {
     return new TypeCheckFailure("Handler for " + fieldName + " is not a function");
   }
 
-  static TypeCheckFailure makeMergeHandlerTypeMismatchError(Expr type1, Expr type2) {
+  static final TypeCheckFailure makeMergeHandlerTypeMismatchError(Expr type1, Expr type2) {
     return new TypeCheckFailure("Handlers should have the same output type");
   }
 
-  static TypeCheckFailure makeMergeHandlerTypeDisallowedError(Expr type) {
+  static final TypeCheckFailure makeMergeHandlerTypeDisallowedError(Expr type) {
     return new TypeCheckFailure("Disallowed handler type");
   }
 
-  static TypeCheckFailure makeMergeInvalidAnnotationError(Expr expected, Expr inferred) {
+  static final TypeCheckFailure makeMergeInvalidAnnotationError(Expr expected, Expr inferred) {
     return new TypeCheckFailure("Expression doesn't match annotation");
   }
 
-  static TypeCheckFailure makeToMapTypeError(Expr type) {
+  static final TypeCheckFailure makeToMapTypeError(Expr type) {
     return new TypeCheckFailure("toMap expects a record value");
   }
 
-  static TypeCheckFailure makeToMapRecordKindError(Expr type) {
+  static final TypeCheckFailure makeToMapRecordKindError(Expr type) {
     return new TypeCheckFailure("toMap expects a record of kind Type");
   }
 
-  static TypeCheckFailure makeToMapRecordTypeMismatchError(Expr type1, Expr type2) {
+  static final TypeCheckFailure makeToMapRecordTypeMismatchError(Expr type1, Expr type2) {
     return new TypeCheckFailure("toMap expects a homogenous record");
   }
 
-  static TypeCheckFailure makeToMapResultTypeMismatchError(Expr expected, Expr inferred) {
+  static final TypeCheckFailure makeToMapResultTypeMismatchError(Expr expected, Expr inferred) {
     return new TypeCheckFailure("toMap result type doesn't match annotation");
   }
 
-  static TypeCheckFailure makeToMapMissingAnnotationError() {
+  static final TypeCheckFailure makeToMapMissingAnnotationError() {
     return new TypeCheckFailure("An empty toMap requires a type annotation");
   }
 
-  static TypeCheckFailure makeToMapInvalidAnnotationError(Expr type) {
+  static final TypeCheckFailure makeToMapInvalidAnnotationError(Expr type) {
     return new TypeCheckFailure("An empty toMap was annotated with an invalid type");
   }
 }

--- a/modules/core/src/main/java/org/dhallj/core/typechecking/Universe.java
+++ b/modules/core/src/main/java/org/dhallj/core/typechecking/Universe.java
@@ -8,9 +8,9 @@ public enum Universe {
   SORT;
 
   public final Universe max(Universe other) {
-    if (this.equals(SORT) || other.equals(SORT)) {
+    if (this == SORT || other == SORT) {
       return SORT;
-    } else if (this.equals(KIND) || other.equals(KIND)) {
+    } else if (this == KIND || other == KIND) {
       return KIND;
     } else {
       return TYPE;
@@ -18,15 +18,12 @@ public enum Universe {
   }
 
   public final Expr toExpr() {
-    switch (this) {
-      case TYPE:
-        return Expr.Constants.TYPE;
-      case KIND:
-        return Expr.Constants.KIND;
-      case SORT:
-        return Expr.Constants.SORT;
-      default:
-        return null;
+    if (this == TYPE) {
+      return Expr.Constants.TYPE;
+    } else if (this == KIND) {
+      return Expr.Constants.KIND;
+    } else {
+      return Expr.Constants.SORT;
     }
   }
 
@@ -50,7 +47,7 @@ public enum Universe {
   }
 
   public static Universe functionCheck(Universe input, Universe output) {
-    if (output.equals(Universe.TYPE)) {
+    if (output == Universe.TYPE) {
       return Universe.TYPE;
     } else {
       return input.max(output);

--- a/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
+++ b/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
@@ -26,6 +26,8 @@ class TypeCheckingUnitSuite extends ParsingTypeCheckingSuite("type-inference/suc
 class TypeCheckingRegressionSuite extends TypeCheckingSuite("type-inference/success/regression")
 class TypeCheckingOtherSuite extends TypeCheckingSuite("type-inference/success") {
   override def slow = Set("prelude")
+  // Depends on http://csrng.net/, which is rate-limited (and also currently entirely down).
+  override def ignored = Set("CacheImports", "CacheImportsCanonicalize")
 }
 class TypeCheckingFailureUnitSuite extends TypeCheckingFailureSuite("type-inference/failure/unit")
 


### PR DESCRIPTION
This PR does two unrelated things:

* Temporarily ignores a couple of tests that depend on csrng.net, which is down. (These tests are being changed to not have this dependency, at which point we'll unignore them.)
* Adds a string length check to avoid looking at the first character in a possibly-empty string (right now the argument should never be empty, but this might change).