### PR TITLE
Fix minor issues in parser

### DIFF
--- a/modules/parser/src/main/java/org/dhallj/parser/support/ParsingHelpers.java
+++ b/modules/parser/src/main/java/org/dhallj/parser/support/ParsingHelpers.java
@@ -165,11 +165,7 @@ final class ParsingHelpers {
   }
 
   static final String reEscape(String input) {
-    return input
-        .replace("\\", "\\\\")
-        .replace("\n", "\\n")
-        .replace("'''", "''")
-        .replace("''${", "\\${");
+    return input.replace("\\", "\\\\").replace("\n", "\\n");
   }
 
   static final Expr.Parsed makeSingleQuotedTextLiteral(

--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -122,7 +122,7 @@ TOKEN: {
   | <EQUIVALENT: "===" | "\u2261">
 
   | <DOUBLE_QUOTE_START: "\"">: WITHIN_DOUBLE_QUOTE
-  | <SINGLE_QUOTE_START: "''\n">: WITHIN_SINGLE_QUOTE
+  | <SINGLE_QUOTE_START: "''" ("\n" | "\r\n")>: WITHIN_SINGLE_QUOTE
   | <PARENS_OPEN: "(">
   | <PARENS_CLOSE: ")">
   | <BRACKET_OPEN: "[">
@@ -218,16 +218,16 @@ TOKEN: {
     | ("\\u" <UNICODE_ESCAPE>)
     | <VALID_NON_ASCII>
   )+> |
-  <#UNICODE_ESCAPE: <UNBRACED_ESCAPE> | ("{" <BRACED_CODEPOINT> "}")> |
+  <#UNICODE_ESCAPE: <UNBRACED_ESCAPE> | ("{" <BRACED_ESCAPE> "}")> |
   <#UNBRACED_ESCAPE:
       ((<DIGIT> | "A" | "B" | "C" | "a" | "b" | "c") (<HEX_DIGIT>){3})
-    | ("D" ["0"-"7"] <HEX_DIGIT> <HEX_DIGIT>)
+    | (("D" | "d") ["0"-"7"] <HEX_DIGIT> <HEX_DIGIT>)
     | (("E" | "e") (<HEX_DIGIT>){3})
     | (("F" | "f") <HEX_DIGIT> <HEX_DIGIT> ("A" | "B" | "C" | "D" | "a" | "b" | "c" | "d"))
   > |
   <#BRACED_ESCAPE: ("0")* <BRACED_CODEPOINT>> |
   <#BRACED_CODEPOINT: ((["0"-"9"] | ["A"-"F"] | ["a"-"f"] | "10") <UNICODE_SUFFIX>) | <UNBRACED_ESCAPE> | ((<HEX_DIGIT>){3})+> |
-  <#UNICODE_SUFFIX: ((<DIGIT> | ["A"-"E"] | ["a"-"e"]) (<HEX_DIGIT>){3}) | ("F" <HEX_DIGIT> <HEX_DIGIT> (<DIGIT> | ["A"-"D"] | ["a"-"d"]))>
+  <#UNICODE_SUFFIX: ((<DIGIT> | ["A"-"E"] | ["a"-"e"]) (<HEX_DIGIT>){3}) | (("F" | "f") <HEX_DIGIT> <HEX_DIGIT> (<DIGIT> | ["A"-"D"] | ["a"-"d"]))>
 }
 <WITHIN_DOUBLE_QUOTE> TOKEN: { <DOUBLE_QUOTE_END: "\"">: DEFAULT }
 
@@ -237,6 +237,8 @@ TOKEN: {
     braceDepth.push(0);
     SwitchTo(DEFAULT);
   } |
+  <ESCAPED_QUOTE_PAIR: "'''"> |
+  <ESCAPED_INTERPOLATION: "''${"> |
   <SINGLE_QUOTE_CHARS: (<ASCII> | <VALID_NON_ASCII> | "\t" | "\n" | "\r\n")>
 }
 <WITHIN_SINGLE_QUOTE> TOKEN: { <SINGLE_QUOTE_END: "''">: DEFAULT }
@@ -302,15 +304,27 @@ List<Map.Entry<String, Expr.Parsed>> SINGLE_QUOTE_CONTINUE(): {
 
     (
       <SINGLE_QUOTE_INTERPOLATION> expr=COMPLETE_EXPRESSION() <BRACE_CLOSE> continuation=SINGLE_QUOTE_CONTINUE()
+    | token=<ESCAPED_QUOTE_PAIR> continuation=SINGLE_QUOTE_CONTINUE()
+    | token=<ESCAPED_INTERPOLATION> continuation=SINGLE_QUOTE_CONTINUE()
     | token=<SINGLE_QUOTE_CHARS> continuation=SINGLE_QUOTE_CONTINUE()
     | <SINGLE_QUOTE_END>
     ) {
       if (continuation == null) {
         return new ArrayList<Map.Entry<String, Expr.Parsed>>();
       } else {
-        continuation.add(
-          new SimpleImmutableEntry<>(token == null ? null : token.image, expr)
-        );
+        String value = null;
+
+        if (token != null) {
+          value = token.image;
+
+          if (value.equals("'''")) {
+            value = "''";
+          } else if (value.equals("''${")) {
+            value = "${";
+          }
+        }
+
+        continuation.add(new SimpleImmutableEntry<>(value, expr));
         return continuation;
       }
     }

--- a/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
+++ b/modules/parser/src/test/scala/org/dhallj/parser/DhallParserSuite.scala
@@ -78,4 +78,14 @@ class DhallParserSuite extends FunSuite() {
   test("fail on URLs with quoted paths") {
     intercept[ParsingFailure](DhallParser.parse("https://example.com/foo/\"bar?baz\"?qux"))
   }
+
+  test("handle single-quoted escape sequences") {
+    val expected = Expr.makeTextLiteral("foo '' bar ${ baz '''' qux")
+
+    val input = """''
+foo ''' bar ''${ baz '''''' qux''"""
+
+    assertEquals(DhallParser.parse(input): Expr, expected)
+
+  }
 }


### PR DESCRIPTION
Closes #76. The issue is that the parser wasn't correctly handling the `'''` and `''${` escapes in multi-line strings:

```scala
scala> import org.dhallj.syntax._
import org.dhallj.syntax._

scala> val input = """''
     | foo ''' bar ''${ baz''"""
val input: String =
''
foo ''' bar ''${ baz''

scala> input.parseExpr
org.dhallj.parser.support.TokenMgrException: Lexical error at line 2, column 8.  Encountered: " " (32), after : "\'"
  at org.dhallj.parser.support.JavaCCParserTokenManager.getNextToken(JavaCCParserTokenManager.java:7794)
  at org.dhallj.parser.support.JavaCCParser.jj_scan_token(JavaCCParser.java:3774)
  at org.dhallj.parser.support.JavaCCParser.jj_3_3(JavaCCParser.java:2746)
  at org.dhallj.parser.support.JavaCCParser.jj_2_3(JavaCCParser.java:2122)
  at org.dhallj.parser.support.JavaCCParser.SELECTOR_EXPRESSION(JavaCCParser.java:1100)
  at org.dhallj.parser.support.JavaCCParser.COMPLETION_EXPRESSION(JavaCCParser.java:1157)
  at org.dhallj.parser.support.JavaCCParser.IMPORT_EXPRESSION(JavaCCParser.java:1294)
  at org.dhallj.parser.support.JavaCCParser.APPLICATION_EXPRESSION(JavaCCParser.java:1391)
  at org.dhallj.parser.support.JavaCCParser.OPERATOR_EXPRESSION(JavaCCParser.java:1502)
  at org.dhallj.parser.support.JavaCCParser.FUNCTION_TYPE_OR_ANNOTATED_EXPRESSION(JavaCCParser.java:1960)
  at org.dhallj.parser.support.JavaCCParser.BASE_EXPRESSION(JavaCCParser.java:2061)
  at org.dhallj.parser.support.JavaCCParser.COMPLETE_EXPRESSION(JavaCCParser.java:2084)
  at org.dhallj.parser.support.JavaCCParser.TOP_LEVEL(JavaCCParser.java:2098)
  at org.dhallj.parser.support.Parser.parse(Parser.java:12)
  at org.dhallj.parser.DhallParser.parse(DhallParser.java:11)
  at org.dhallj.syntax.package$DhallStringOps$.parseExpr$extension(package.scala:13)
  ... 40 elided
```

After this change it works as expected:

```scala
scala> input.parseExpr
res0: Either[org.dhallj.core.DhallException.ParsingFailure,org.dhallj.core.Expr] = Right("foo '' bar ${ baz")
```
I've also fixed a couple of small issues in Unicode escaping.