### PR TITLE
Allow quoted labels to be empty

### DIFF
--- a/modules/parser/src/main/javacc/JavaCCParser.jj
+++ b/modules/parser/src/main/javacc/JavaCCParser.jj
@@ -101,7 +101,7 @@ TOKEN: {
     | "Optional"
     | "List"
   >
-  | <QUOTED_LABEL: "`" (["\u0020"-"\u005f"] | ["\u0061"-"\u007e"])+ "`">
+  | <QUOTED_LABEL: "`" (["\u0020"-"\u005f"] | ["\u0061"-"\u007e"])* "`">
   | <SIMPLE_LABEL: (<ALPHA> | "_") (<ALPHA> | <DIGIT> | "_" | "-" | "/" )*>
   | <LAMBDA: "\\" | "\u03bb">
   | <ARROW: "->" | "\u2192">

--- a/modules/testing/src/main/scala/org/dhallj/testing/ArbitraryInstances.scala
+++ b/modules/testing/src/main/scala/org/dhallj/testing/ArbitraryInstances.scala
@@ -17,7 +17,7 @@ trait ArbitraryInstances {
   }
 
   def isValidName(name: String): Boolean =
-    List('\u0000', '\u0001', '`').forall(c => name.indexOf(c.toInt) == -1) && name.nonEmpty
+    List('\u0000', '\u0001', '`').forall(c => name.indexOf(c.toInt) == -1)
 
   def genIdentifier: Gen[Expr] =
     for {


### PR DESCRIPTION
See [this change](https://github.com/dhall-lang/dhall-lang/pull/980) to the language spec.

I think it's reasonable to merge this on master before 17.0.0 is released, since it's a small change that doesn't affect any existing Dhall code (also I think it's unlikely we'll need a new release before 17.0.0 is out).