### PR TITLE
Fix some problems in import tests

### DIFF
--- a/modules/core/src/main/java/org/dhallj/core/Expr.java
+++ b/modules/core/src/main/java/org/dhallj/core/Expr.java
@@ -592,10 +592,10 @@ public abstract class Expr {
     public static final Expr LOCATION_TYPE =
         makeUnionType(
             new Entry[] {
-              new SimpleImmutableEntry<>("Local", TEXT),
-              new SimpleImmutableEntry<>("Remote", TEXT),
               new SimpleImmutableEntry<>("Environment", TEXT),
-              new SimpleImmutableEntry<>("Missing", null)
+              new SimpleImmutableEntry<>("Local", TEXT),
+              new SimpleImmutableEntry<>("Missing", null),
+              new SimpleImmutableEntry<>("Remote", TEXT)
             });
     public static final String MAP_KEY_FIELD_NAME = "mapKey";
     public static final String MAP_VALUE_FIELD_NAME = "mapValue";

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
@@ -110,10 +110,11 @@ final private class ResolveImportsVisitor[F[_] <: AnyRef](
             case _ =>
               for {
                 e <- loadWithSemiSemanticCache(imp, mode, hash)
-                bs = e.alphaNormalize.getEncodedBytes
+                n = e.normalize.alphaNormalize
+                bs = n.getEncodedBytes
                 _ <- checkHashesMatch(bs, hash)
                 _ <- semanticCache.put(hash, bs)
-              } yield e
+              } yield n
           }
         } yield e
 

--- a/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ResolveImportsVisitor.scala
@@ -32,7 +32,7 @@ final private class ResolveImportsVisitor[F[_] <: AnyRef](
 )(implicit
   Client: Client[F],
   F: Async[F]
-) extends LiftVisitor[F](F) {
+) extends LiftVisitor[F](F, true) {
   def this(
     semanticCache: ImportCache[F],
     semiSemanticCache: ImportCache[F],

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuccessSuite.scala
@@ -2,7 +2,7 @@ package org.dhallj.tests.acceptance
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 import org.dhallj.core.Expr
 import org.dhallj.core.binary.Decode.decode
@@ -50,8 +50,7 @@ trait ParsingInput extends Input[Expr] {
 trait CachedResolvingInput extends Input[Expr] {
 
   override def parseInput(path: String, input: String): Expr = {
-    //TODO this should only be for import tests (I think)
-    val parsed = DhallParser.parse(s"./$path")
+    val parsed = DhallParser.parse(new String(Files.readAllBytes(Paths.get(path))))
 
     if (parsed.isResolved) parsed
     else {
@@ -69,8 +68,7 @@ trait CachedResolvingInput extends Input[Expr] {
 
 trait ResolvingInput extends Input[Expr] {
   def parseInput(path: String, input: String): Expr = {
-    //TODO this should only be for import tests (I think)
-    val parsed = DhallParser.parse(s"./$path")
+    val parsed = DhallParser.parse(new String(Files.readAllBytes(Paths.get(path))))
 
     if (parsed.isResolved) parsed
     else {

--- a/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuite.scala
+++ b/tests/src/main/scala/org/dhallj/tests/acceptance/AcceptanceSuite.scala
@@ -18,7 +18,7 @@ trait AcceptanceSuite extends FunSuite {
   /**
    * Test names to ignore.
    */
-  def ignored: Set[String] = Set.empty
+  def ignored: String => Boolean = Set.empty
 
   /**
    * Names of tests that are slow.

--- a/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
+++ b/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
@@ -25,7 +25,10 @@ class TypeCheckingOtherSuite extends TypeCheckingSuite("type-inference/success")
   override def ignored = Set("CacheImports", "CacheImportsCanonicalize")
 }
 class TypeCheckingFailureUnitSuite extends TypeCheckingFailureSuite("type-inference/failure/unit")
-class TypeCheckingPreludeSuite extends TypeCheckingSuite("type-inference/success/prelude", true)
+class TypeCheckingPreludeSuite extends TypeCheckingSuite("type-inference/success/prelude", true) {
+  // Temporary workaround awaiting dhall-lang#1198.
+  override def ignored = _.startsWith("Monoid/")
+}
 
 class ParsingUnitSuite extends ParsingSuite("parser/success/unit")
 class ParsingTextSuite extends ParsingSuite("parser/success/text")

--- a/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
+++ b/tests/src/test/scala/org/dhallj/tests/acceptance/AcceptanceSuites.scala
@@ -22,7 +22,8 @@ class TypeCheckingRegressionSuite extends TypeCheckingSuite("type-inference/succ
 class TypeCheckingOtherSuite extends TypeCheckingSuite("type-inference/success") {
   override def slow = Set("prelude")
   // Depends on http://csrng.net/, which is rate-limited (and also currently entirely down).
-  override def ignored = Set("CacheImports", "CacheImportsCanonicalize")
+  // Temporary workaround awaiting dhall-lang#1198 (prelude only).
+  override def ignored = Set("CacheImports", "CacheImportsCanonicalize", "prelude")
 }
 class TypeCheckingFailureUnitSuite extends TypeCheckingFailureSuite("type-inference/failure/unit")
 class TypeCheckingPreludeSuite extends TypeCheckingSuite("type-inference/success/prelude", true) {


### PR DESCRIPTION
The fact that we were resolving imports in the expression `./<path>` instead of the contents of the path was hiding some problems.