### PR TITLE
Use Scala 2 by default in console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 
 ThisBuild / organization := "org.dhallj"
 ThisBuild / crossScalaVersions := List("2.12.14", "2.13.6", "3.0.1")
-ThisBuild / scalaVersion := crossScalaVersions.value.last
+ThisBuild / scalaVersion := crossScalaVersions.value.filter(_.startsWith("2")).last
 
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8")
 ThisBuild / githubWorkflowPublishTargetBranches := Nil


### PR DESCRIPTION
I hate that Scala 3 doesn't respect `initialCommands` and just in general the experience is bad in ways I don't want to deal with here.