### PR TITLE
Fix cache bug and fail on cache creation failures

### DIFF
--- a/modules/imports/src/main/scala/org/dhallj/imports/ImportCache.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ImportCache.scala
@@ -76,7 +76,7 @@ object ImportCache {
         cache <- cacheO.fold[F[ImportCache[F]]](F.as(warnCacheNotCreated, new NoopImportCache[F]))(F.pure)
       } yield cache
 
-    def isWindows = System.getProperty("os.name").toLowerCase.contains("Windows")
+    def isWindows = System.getProperty("os.name").toLowerCase.contains("windows")
 
     def warnCacheNotCreated: F[Unit] =
       F.delay(

--- a/modules/imports/src/main/scala/org/dhallj/imports/ImportCache.scala
+++ b/modules/imports/src/main/scala/org/dhallj/imports/ImportCache.scala
@@ -1,10 +1,10 @@
 package org.dhallj.imports
 
-import java.nio.file.{Files, Path, Paths}
-
 import cats.Applicative
 import cats.effect.Async
 import cats.implicits._
+import java.nio.file.{Files, Path, Paths}
+import org.dhallj.core.DhallException.ResolutionFailure
 
 trait ImportCache[F[_]] {
   def get(key: Array[Byte]): F[Option[Array[Byte]]]
@@ -73,17 +73,10 @@ object ImportCache {
           if (isWindows)
             makeCacheFromEnvVar("LOCALAPPDATA", "")
           else makeCacheFromEnvVar("HOME", ".cache")
-        cache <- cacheO.fold[F[ImportCache[F]]](F.as(warnCacheNotCreated, new NoopImportCache[F]))(F.pure)
+        cache <- F.fromOption(cacheO, new ResolutionFailure("Failed to create cache"))
       } yield cache
 
     def isWindows = System.getProperty("os.name").toLowerCase.contains("windows")
-
-    def warnCacheNotCreated: F[Unit] =
-      F.delay(
-        println(
-          "WARNING: failed to create cache at either $XDG_CACHE_HOME}/dhall or $HOME/.cache/dhall. Are these locations writable?"
-        )
-      )
 
     for {
       xdgCache <- makeCacheFromEnvVar("XDG_CACHE_HOME", "")


### PR DESCRIPTION
The first commit fixes a definite bug. The second removes a warning `println` I hadn't noticed before. I've changed it to fail hard on any cache creation failure, which seems reasonable to me. If we really want a warning here, we could come up with some other mechanism, but I'd prefer to avoid `println`.